### PR TITLE
support single edge/node label

### DIFF
--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -159,8 +159,8 @@ def _is_node_attr_match(
     host_node = host.nodes[host_node_id]
 
     for attr, val in motif_node.items():
-        if attr == '__type__':
-            if val and val - host_node.get("__type__", set()):
+        if attr == '__labels__':
+            if val and val - host_node.get("__labels__", set()):
                 return False
             continue
         if host_node.get(attr) != val:
@@ -178,7 +178,7 @@ def _is_edge_attr_match(
 ) -> bool:
     """
     Check if an edge in the host graph matches the attributes in the motif.
-    This also check the __type__ of edges.
+    This also check the __labels__ of edges.
 
     Arguments:
         motif_edge_id (str): The motif edge ID
@@ -194,8 +194,8 @@ def _is_edge_attr_match(
     host_edge = host.edges[host_edge_id]
 
     for attr, val in motif_edge.items():
-        if attr == '__type__':
-            if val and val - host_edge.get("__type__", set()):
+        if attr == '__labels__':
+            if val and val - host_edge.get("__labels__", set()):
                 return False
             continue
         if host_edge.get(attr) != val:
@@ -403,7 +403,7 @@ class _GrandCypherTransformer(Transformer):
             new_motifs = []
             min_hop = motif.edges[u, v]["__min_hop__"]
             max_hop = motif.edges[u, v]["__max_hop__"]
-            edge_type = motif.edges[u, v]["__type__"]
+            edge_type = motif.edges[u, v]["__labels__"]
             hops = []
             if min_hop == 0:
                 new_motif = nx.DiGraph()
@@ -415,7 +415,7 @@ class _GrandCypherTransformer(Transformer):
             for i in range(max(min_hop, 1), max_hop):
                 new_edges = [u] + hops + [v]
                 new_motif = nx.DiGraph()
-                new_motif.add_edges_from(list(zip(new_edges[:-1], new_edges[1:])), __type__ = edge_type)
+                new_motif.add_edges_from(list(zip(new_edges[:-1], new_edges[1:])), __labels__ = edge_type)
                 new_motif.add_node(u, **motif.nodes[u])
                 new_motif.add_node(v, **motif.nodes[v])
                 new_motifs.append((new_motif, {(u, v): tuple(new_edges)}))
@@ -486,7 +486,7 @@ class _GrandCypherTransformer(Transformer):
         if len(match_clause) == 1:
             # This is just a node match:
             u, ut, js = match_clause[0]
-            self._motif.add_node(u.value, __type__ = ut, **js)
+            self._motif.add_node(u.value, __labels__ = ut, **js)
             return
         for start in range(0, len(match_clause) - 2, 2):
             ((u, ut, ujs), (g, t, d, minh, maxh), (v, vt, vjs)) = match_clause[start : start + 3]
@@ -510,10 +510,10 @@ class _GrandCypherTransformer(Transformer):
             if t:
                 t = set([t])
             self._motif.add_edges_from(
-                edges, __min_hop__ = minh, __max_hop__ = maxh, __is_hop__ = ish, __type__ = t)
+                edges, __min_hop__ = minh, __max_hop__ = maxh, __is_hop__ = ish, __labels__ = t)
             
-            self._motif.add_node(u, __type__=ut, **ujs)
-            self._motif.add_node(v, __type__=vt, **vjs)
+            self._motif.add_node(u, __labels__=ut, **ujs)
+            self._motif.add_node(v, __labels__=vt, **vjs)
 
     def where_clause(self, where_clause: tuple):
         self._where_condition = where_clause[0]

--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -56,6 +56,8 @@ condition           : entity_id op entity_id_or_value
 ?entity_id_or_value : entity_id
                     | value
                     | "NULL"i -> null
+                    | "TRUE"i -> true
+                    | "FALSE"i -> false
 
 op                  : "==" -> op_eq
                     | "=" -> op_eq
@@ -114,6 +116,8 @@ key                 : CNAME
 ?value              : ESTRING
                     | NUMBER
                     | "NULL"i -> null
+                    | "TRUE"i -> true
+                    | "FALSE"i -> false
 
 
 %import common.CNAME            -> CNAME
@@ -561,6 +565,8 @@ class _GrandCypherTransformer(Transformer):
             return (True, entity_id, operator, value)
 
     null = lambda self, _: None
+    true = lambda self, _: True
+    false = lambda self, _: False
     ESTRING = v_args(inline=True)(eval)
     NUMBER = v_args(inline=True)(eval)
 

--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -90,6 +90,11 @@ edge_match          : LEFT_ANGLE? "--" RIGHT_ANGLE?
                     | LEFT_ANGLE? "-[" "*" MIN_HOP  ".." MAX_HOP "]-" RIGHT_ANGLE?
                     | LEFT_ANGLE? "-[" CNAME "*" MIN_HOP "]-" RIGHT_ANGLE?
                     | LEFT_ANGLE? "-[" CNAME "*" MIN_HOP  ".." MAX_HOP "]-" RIGHT_ANGLE?
+                    | LEFT_ANGLE? "-[" ":" TYPE "*" MIN_HOP "]-" RIGHT_ANGLE?
+                    | LEFT_ANGLE? "-[" ":" TYPE "*" MIN_HOP  ".." MAX_HOP "]-" RIGHT_ANGLE?
+                    | LEFT_ANGLE? "-[" CNAME ":" TYPE "*" MIN_HOP "]-" RIGHT_ANGLE?
+                    | LEFT_ANGLE? "-[" CNAME ":" TYPE "*" MIN_HOP  ".." MAX_HOP "]-" RIGHT_ANGLE?
+
 
 
 LEFT_ANGLE          : "<"

--- a/grandcypher/test_parser.py
+++ b/grandcypher/test_parser.py
@@ -762,7 +762,7 @@ class TestType():
         """
 
         res = GrandCypher(host).run(qry)
-        print(res)
+
         assert len(res) == 3
         assert res["A"] == ["x", "y", "z", "x", "y", "z", "x", "y", "z"]
         assert res["B"] == ["x", "y", "z", "y", "z", "x", "z", "x", "y"]
@@ -875,18 +875,18 @@ class TestSpecialCases:
 
     def test_two_edge_hop_with_edge_node_type(self):
         host = nx.DiGraph()
-        host.add_node("C_1_1", __labels__ = set(["X"]), head="True")
+        host.add_node("C_1_1", __labels__ = set(["X"]), head=True)
         host.add_node("C_1_2", __labels__ = set(["X"]))
         host.add_node("C_1_3", __labels__ = set(["X"]))
-        host.add_node("C_2_1", name="C_2_1", __labels__ = set(["X"]), head="True")
+        host.add_node("C_2_1", name="C_2_1", __labels__ = set(["X"]), head=True)
         host.add_node("C_2_2", __labels__ = set(["X"]))
         host.add_edge("C_1_1", "C_1_2", __labels__ = set(["b"]))
         host.add_edge("C_1_2", "C_1_3", __labels__ = set(["b"]))
         host.add_edge("C_2_1", "C_2_2", __labels__ = set(["b"]))
 
-        host.add_node("a_1_1", __labels__ = set(["Y"]), head="True")
+        host.add_node("a_1_1", __labels__ = set(["Y"]), head=True)
         host.add_node("a_1_2", __labels__ = set(["Y"]))
-        host.add_node("a_2_1", __labels__ = set(["Y"]), head="True")
+        host.add_node("a_2_1", __labels__ = set(["Y"]), head=True)
         host.add_edge("a_1_1", "a1_2", __labels__ = set(["b"]))
 
         host.add_edge("C_1_1", "a_1_1", __labels__ = set(["i"]))
@@ -895,7 +895,8 @@ class TestSpecialCases:
         host.add_edge("C_2_2", "a_2_1", __labels__ = set(["i"]))
 
         qry = """
-        MATCH (A:X{head:"True"}) -[:b*0..5]-> (B:X) -[:i*0..1]-> (c)
+        MATCH (A:X) -[:b*0..5]-> (B:X) -[:i*0..1]-> (c)
+        where A.head is True
         return A, B, c
         """
 

--- a/grandcypher/test_parser.py
+++ b/grandcypher/test_parser.py
@@ -692,9 +692,9 @@ class TestType():
         host.add_node("x")
         host.add_node("y")
         host.add_node("z")
-        host.add_edge("x", "y", __type__={"Edge", "XY"}, bar="1")
-        host.add_edge("y", "z", __type__={"Edge", "YZ"}, bar="2")
-        host.add_edge("z", "x", __type__={"Edge", "ZX"}, bar="3")
+        host.add_edge("x", "y", __labels__={"Edge", "XY"}, bar="1")
+        host.add_edge("y", "z", __labels__={"Edge", "YZ"}, bar="2")
+        host.add_edge("z", "x", __labels__={"Edge", "ZX"}, bar="3")
 
         qry = """
         MATCH (A)-[:XY]->(B)
@@ -732,9 +732,9 @@ class TestType():
         host.add_node("x")
         host.add_node("y")
         host.add_node("z")
-        host.add_edge("x", "y", __type__={"Edge", "XY"})
-        host.add_edge("y", "z", __type__={"Edge", "YZ"})
-        host.add_edge("z", "x", __type__={"Edge", "ZX"})
+        host.add_edge("x", "y", __labels__={"Edge", "XY"})
+        host.add_edge("y", "z", __labels__={"Edge", "YZ"})
+        host.add_edge("z", "x", __labels__={"Edge", "ZX"})
 
         qry = """
         MATCH (A)-[:XY*2]->(B)
@@ -768,8 +768,8 @@ class TestType():
         assert res["B"] == ["x", "y", "z", "y", "z", "x", "z", "x", "y"]
         assert res["r"] == [
             [None], [None], [None],
-            [{'__type__': {'Edge', 'XY'}}], [{'__type__': {'Edge', 'YZ'}}], [{'__type__': {'Edge', 'ZX'}}],
-            [{'__type__': {'Edge', 'XY'}}, {'__type__': {'Edge', 'YZ'}}], [{'__type__': {'Edge', 'YZ'}}, {'__type__': {'Edge', 'ZX'}}], [{'__type__': {'Edge', 'ZX'}}, {'__type__': {'Edge', 'XY'}}]
+            [{'__labels__': {'Edge', 'XY'}}], [{'__labels__': {'Edge', 'YZ'}}], [{'__labels__': {'Edge', 'ZX'}}],
+            [{'__labels__': {'Edge', 'XY'}}, {'__labels__': {'Edge', 'YZ'}}], [{'__labels__': {'Edge', 'YZ'}}, {'__labels__': {'Edge', 'ZX'}}], [{'__labels__': {'Edge', 'ZX'}}, {'__labels__': {'Edge', 'XY'}}]
         ]
 
     def test_host_no_node_type(self):
@@ -793,9 +793,9 @@ class TestType():
 
     def test_node_type(self):
         host = nx.DiGraph()
-        host.add_node("x", __type__ = set(["Node", "X"]), foo="1")
-        host.add_node("y", __type__ = set(["Node", "Y"]), foo="2")
-        host.add_node("z", __type__ = set(["Node", "Z"]), foo="3")
+        host.add_node("x", __labels__ = set(["Node", "X"]), foo="1")
+        host.add_node("y", __labels__ = set(["Node", "Y"]), foo="2")
+        host.add_node("z", __labels__ = set(["Node", "Z"]), foo="3")
         host.add_edge("x", "y")
         host.add_edge("y", "z")
         host.add_edge("z", "x")


### PR DESCRIPTION
- support single edge label matching. This requires the host graph to have `__labels__` set as a set. Otherwise, errors can be raised or no matches can be found
- support single node label matching. This requires the host graph to have `__labels__` set as a set. Otherwise, errors can be raised or no matches can be found
- return an explicit edge-hop relation is always a list of relations regardless the hop step.
- promote node json condition to is_node_attr_match
- support for True/False values
