### PR TITLE
Add path groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # CHANGELOG
 
-### **0.5.0** (Unreleased)
+### **0.6.0** (February 15 2024)
+
+> New path group operator
+
+#### Features
+
+-   Support for path group operators (#37)
+
+### **0.5.0** (February 13 2024)
 
 > Lots of language support for new query operators.
 

--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -478,8 +478,7 @@ class _GrandCypherTransformer(Transformer):
 
         # Single match clause iterator
         if iterators and len(iterators) == 1:
-            for x, match in enumerate(iterators[0]):
-                yield match
+            yield from iterators[0]
 
         # Multi match clause, requires a cartesian join
         else:

--- a/grandcypher/test_queries.py
+++ b/grandcypher/test_queries.py
@@ -1157,3 +1157,23 @@ class TestNot:
 
         res = GrandCypher(host).run(qry)
         assert len(res["Instrument"]) == 1
+
+
+class TestPath:
+    def test_path(self):
+        host = nx.DiGraph()
+        host.add_node("x", name="x")
+        host.add_node("y", name="y")
+        host.add_node("z", name="z")
+
+        host.add_edge("x", "y", foo="bar")
+        host.add_edge("y", "z",)
+
+        qry = """
+        MATCH P = ()-[r*2]->()
+        RETURN P
+        LIMIT 1
+        """
+
+        res = GrandCypher(host).run(qry)
+        assert len(res["P"][0]) == 5

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="grand-cypher",
-    version="0.5.0",
+    version="0.6.0",
     author="Jordan Matelsky",
     author_email="opensource@matelsky.com",
     description="Query Grand graphs using Cypher",


### PR DESCRIPTION
Initial implementation of #26 as discussed in #35. 

After thinking about how a standard node and relationship are returned, this initial implementation mirrors that for paths.

For example:

```cypher
MATCH (A)-[R]->(B)
RETURN A, R, B
```

Returns:

```
(A node id, R relationship attributes, B node id)
```

With this change:

```cypher
MATCH P = (A)-[R]->(B)
RETURN P
```

Returns:

[node id1, {relationship attributes} node id2]

The plumbing is now in place to return the data in whatever format we think makes sense. 

I think I modified the lark spec to make the path_clause optional. The tests pass. 