### PR TITLE
Adds support for multigraphs

### DIFF
--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -431,26 +431,25 @@ class _GrandCypherTransformer(Transformer):
                 if entity_attribute:
                     # Get the correct entity from the target host graph,
                     # and then return the attribute:
-                    if isinstance(self._motif, nx.MultiDiGraph):
-                        # unroll the relations in the multigraph
-                        unnested_ret = []
+                    if isinstance(self._motif, nx.MultiDiGraph) and len(motif_edge_labels) > 0:
+                        # filter the retrieved edge(s) based on the motif edge labels
+                        filtered_ret = []
                         for r in ret:
 
-                            if motif_edge_labels == set():
-                                unnested_ret.append(r)
-                            elif any([i.get('__labels__', None).issubset(motif_edge_labels) for i in r.values()]):
-                                unnested_ret.append(r)
-                        
-                        ret = unnested_ret
+                            if any([i.get('__labels__', None).issubset(motif_edge_labels) for i in r.values()]):
+                                filtered_ret.append(r)
 
-                    n_ret = []
+                        ret = filtered_ret
+
+                    # get the attribute from the retrieved edge(s)
+                    ret_with_attr = []
                     for r in ret:
-                        new_ret = {}
+                        r_attr = {}
                         for i, v in r.items():
-                            new_ret[i] = v.get(entity_attribute, None)
-                        n_ret.append(new_ret)
+                            r_attr[i] = v.get(entity_attribute, None)
+                        ret_with_attr.append(r_attr)
 
-                    ret = n_ret
+                    ret = ret_with_attr
 
             result[data_path] = list(ret)[offset_limit]
 
@@ -710,7 +709,7 @@ class _GrandCypherTransformer(Transformer):
         new_motifs = []
         for motif_1, mapping_1 in motifs_1:
             for motif_2, mapping_2 in motifs_2:
-                motif = nx.MultiDiGraph()
+                motif = nx.DiGraph()
                 motif.add_nodes_from(motif_1.nodes.data())
                 motif.add_nodes_from(motif_2.nodes.data())
                 motif.add_edges_from(motif_1.edges.data())

--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -350,7 +350,7 @@ class _GrandCypherTransformer(Transformer):
         self._target_graph = target_graph
         self._paths = []
         self._where_condition: CONDITION = None
-        self._motif = nx.MultiDiGraph()    #nx.MultiDiGraph()      # nx.DiGraph()
+        self._motif = nx.MultiDiGraph()     # nx.DiGraph()
         self._matches = None
         self._matche_paths = None
         self._return_requests = []
@@ -435,13 +435,25 @@ class _GrandCypherTransformer(Transformer):
                         # unroll the relations in the multigraph
                         unnested_ret = []
                         for r in ret:
-                            unnested_ret.extend(r.values())
-                        
-                        ret = [r for r in unnested_ret if (len(motif_edge_labels) == 0 or r['__labels__'].issubset(motif_edge_labels))]
 
-                    ret = (r.get(entity_attribute, None) for r in ret)
+                            if motif_edge_labels == set():
+                                unnested_ret.append(r)
+                            elif any([i.get('__labels__', None).issubset(motif_edge_labels) for i in r.values()]):
+                                unnested_ret.append(r)
+                        
+                        ret = unnested_ret
+
+                    n_ret = []
+                    for r in ret:
+                        new_ret = {}
+                        for i, v in r.items():
+                            new_ret[i] = v.get(entity_attribute, None)
+                        n_ret.append(new_ret)
+
+                    ret = n_ret
 
             result[data_path] = list(ret)[offset_limit]
+
 
         return result
     
@@ -698,7 +710,7 @@ class _GrandCypherTransformer(Transformer):
         new_motifs = []
         for motif_1, mapping_1 in motifs_1:
             for motif_2, mapping_2 in motifs_2:
-                motif = nx.DiGraph()
+                motif = nx.MultiDiGraph()
                 motif.add_nodes_from(motif_1.nodes.data())
                 motif.add_nodes_from(motif_2.nodes.data())
                 motif.add_edges_from(motif_1.edges.data())


### PR DESCRIPTION
hello again👋 adding support for multigraphs this time
```python
from grandcypher import GrandCypher
import networkx as nx

host = nx.MultiDiGraph()
host.add_node("a", name="Alice", age=30)
host.add_node("b", name="Bob", age=40)
host.add_node("c", name="Charlie", age=50)
host.add_edge("a", "b", __labels__={"friend"}, years=3)
host.add_edge("a", "c", __labels__={"colleague"}, years=10)
host.add_edge("a", "c", __labels__={"parent"}, duration='forever')
host.add_edge("b", "c", __labels__={"colleague"}, duration=10)
host.add_edge("b", "c", __labels__={"mentor"}, years=2)

qry = """
MATCH (a)-[r]->(b)
RETURN a.name, b.name, r.__labels__, r.duration
"""
res = GrandCypher(host).run(qry)
print(res)

'''
{'a.name': ['Alice', 'Alice', 'Bob'], 
'b.name': ['Bob', 'Charlie', 'Charlie'], 
'r.__labels__': [{0: {'friend'}}, {0: {'colleague'}, 1: {'parent'}}, {0: {'colleague'}, 1: {'mentor'}}], 
'r.duration': [{0: None}, {0: None, 1: 'forever'}, {0: 10, 1: None}]}
'''
```