### PR TITLE
Bugfix + Unify digraph and multidigraph behaviour

### DIFF
--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -376,7 +376,7 @@ def _data_path_to_entity_name_attribute(data_path):
 
 class _GrandCypherTransformer(Transformer):
     def __init__(self, target_graph: nx.Graph, limit=None):
-        self._target_graph = nx.MultiDiGraph(target_graph) # target_graph
+        self._target_graph = nx.MultiDiGraph(target_graph)
         self._paths = []
         self._where_condition: CONDITION = None
         self._motif = nx.MultiDiGraph()


### PR DESCRIPTION
I noticed some issues where trying to do `ORDER BY` on edge attributes. This was due to the data structure of the edges specifically because they can support multi edges.

You can reproduce the error by (this PR fixes that):

```python
from grandcypher import GrandCypher
import networkx as nx

host = nx.MultiDiGraph()
host.add_node("a", name="Alice", age=25)
host.add_node("b", name="Bob", age=30)
host.add_node("c", name="Carol", age=20)
host.add_edge("b", "a", __labels__={"paid"}, value=14)
host.add_edge("a", "b", __labels__={"paid"}, value=9)
host.add_edge("a", "b", __labels__={"paid"}, amount=96)
host.add_edge("a", "b", __labels__={"paid"}, value=40)

qry = """
MATCH (n)-[r:paid]->()
RETURN n.name, r.value
ORDER BY r.value ASC
"""
res = GrandCypher(host).run(qry)

print(res)

'''
TypeError: '<' not supported between instances of 'dict' and 'dict'
'''
```

Internally, GrandCypher now treats all graphs as MultiDiGraphs. I think this will make things clearer and require less special handling for future updates.


I also made some changes to the unit tests and added some more for these problematic cases.