### PR TITLE
Filtering within multiedges

### DIFF
--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -334,8 +334,7 @@ def or_(cond_a, cond_b):
 
 def cond_(should_be, entity_id, operator, value) -> CONDITION:
     def inner(
-        match: dict, host: Union[nx.DiGraph, nx.MultiDiGraph], return_endges: list, 
-        return_results: bool = True
+        match: dict, host: Union[nx.DiGraph, nx.MultiDiGraph], return_endges: list
     ) -> bool:
         host_entity_id = entity_id.split(".")
         if host_entity_id[0] in match:
@@ -365,8 +364,8 @@ def cond_(should_be, entity_id, operator, value) -> CONDITION:
                 val = False
 
         if val != should_be:
-            return False, operator_results if return_results else False
-        return True, operator_results if return_results else True
+            return False, operator_results
+        return True, operator_results
 
     return inner
 

--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -84,13 +84,11 @@ op                  : "==" -> op_eq
 
 return_clause       : "return"i distinct_return? return_item ("," return_item)*
 return_item         : (entity_id | aggregation_function | entity_id "." attribute_id) ( "AS"i alias )?
-return_item         : (entity_id | aggregation_function | entity_id "." attribute_id) ( "AS"i alias )?
+alias               : CNAME
 
 aggregation_function : AGGREGATE_FUNC "(" entity_id ( "." attribute_id )? ")"
 AGGREGATE_FUNC       : "COUNT" | "SUM" | "AVG" | "MAX" | "MIN"
 attribute_id         : CNAME
-alias                : CNAME
-alias                : CNAME
 
 distinct_return     : "DISTINCT"i
 limit_clause        : "limit"i NUMBER

--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -314,21 +314,28 @@ CONDITION = Callable[[dict, nx.DiGraph, list], bool]
 
 def and_(cond_a, cond_b) -> CONDITION:
     def inner(match: dict, host: nx.DiGraph, return_endges: list) -> bool:
-        return cond_a(match, host, return_endges) and cond_b(match, host, return_endges)
-
+        condition_a, where_a = cond_a(match, host, return_endges) 
+        condition_b, where_b = cond_b(match, host, return_endges)
+        where_result = [a and b for a, b in zip(where_a, where_b)]
+        return (condition_a and condition_b), where_result
+    
     return inner
 
 
 def or_(cond_a, cond_b):
     def inner(match: dict, host: nx.DiGraph, return_endges: list) -> bool:
-        return cond_a(match, host, return_endges) or cond_b(match, host, return_endges)
+        condition_a, where_a = cond_a(match, host, return_endges) 
+        condition_b, where_b = cond_b(match, host, return_endges)
+        where_result = [a or b for a, b in zip(where_a, where_b)]
+        return (condition_a or condition_b), where_result
 
     return inner
 
 
 def cond_(should_be, entity_id, operator, value) -> CONDITION:
     def inner(
-        match: dict, host: Union[nx.DiGraph, nx.MultiDiGraph], return_endges: list
+        match: dict, host: Union[nx.DiGraph, nx.MultiDiGraph], return_endges: list, 
+        return_results: bool = True
     ) -> bool:
         host_entity_id = entity_id.split(".")
         if host_entity_id[0] in match:
@@ -339,20 +346,27 @@ def cond_(should_be, entity_id, operator, value) -> CONDITION:
             host_entity_id[0] = (match[edge_mapping[0]], match[edge_mapping[1]])
         else:
             raise IndexError(f"Entity {host_entity_id} not in graph.")
-        try:
-            if isinstance(host, nx.MultiDiGraph):
-                # if any of the relations between nodes satisfies condition, return True
-                r_vals = _get_entity_from_host(host, *host_entity_id)
-                r_vals = [r_vals] if not isinstance(r_vals, list) else r_vals
-                val = any(operator(r_val, value) for r_val in r_vals)
-            else:
-                val = operator(_get_entity_from_host(host, *host_entity_id), value)
 
-        except:
-            val = False
+        if isinstance(host, nx.MultiDiGraph):
+            # if any of the relations between nodes satisfies condition, return True
+            r_vals = _get_entity_from_host(host, *host_entity_id)
+            r_vals = [r_vals] if not isinstance(r_vals, list) else r_vals
+            operator_results = []
+            for r_val in r_vals:
+                try:
+                    operator_results.append(operator(r_val, value))
+                except:
+                    operator_results.append(False)
+            val = any(operator_results)
+        else:
+            try:
+                val = operator(_get_entity_from_host(host, *host_entity_id), value)
+            except:
+                val = False
+
         if val != should_be:
-            return False
-        return True
+            return False, operator_results if return_results else False
+        return True, operator_results if return_results else True
 
     return inner
 
@@ -397,6 +411,16 @@ class _GrandCypherTransformer(Transformer):
         self._max_hop = 100
 
     def _lookup(self, data_paths: List[str], offset_limit) -> Dict[str, List]:
+
+        def _filter_edge(edge, where_results):
+            # no where condition -> return edge
+            if where_results == []:
+                return edge
+            else:
+                # exclude edge(s) from multiedge that don't satisfy the where condition
+                edge = {k: v for k, v in edge[0].items() if where_results[k] is True}
+                return [edge]
+            
         if not data_paths:
             return {}
 
@@ -422,7 +446,7 @@ class _GrandCypherTransformer(Transformer):
             if entity_name in motif_nodes:
                 # We are looking for a node mapping in the target graph:
 
-                ret = (mapping[entity_name] for mapping, _ in true_matches)
+                ret = (mapping[0][entity_name] for mapping, _ in true_matches)
                 # by default, just return the node from the host graph
 
                 if entity_attribute:
@@ -436,6 +460,7 @@ class _GrandCypherTransformer(Transformer):
             elif entity_name in self._paths:
                 ret = []
                 for mapping, _ in true_matches:
+                    mapping = mapping[0]
                     path, nodes = [], list(mapping.values())
                     for x, node in enumerate(nodes):
                         # Edge
@@ -454,8 +479,10 @@ class _GrandCypherTransformer(Transformer):
                 # We are looking for an edge mapping in the target graph:
                 is_hop = self._motif.edges[(mapping_u, mapping_v, 0)]["__is_hop__"]
                 ret = (
-                    _get_edge(
-                        self._target_graph, mapping, match_path, mapping_u, mapping_v
+                    _filter_edge(
+                        _get_edge(
+                            self._target_graph, mapping[0], match_path, mapping_u, mapping_v
+                        ), mapping[1]
                     )
                     for mapping, match_path in true_matches
                 )
@@ -479,14 +506,10 @@ class _GrandCypherTransformer(Transformer):
                         filtered_ret = []
                         for r in ret:
 
-                            if any(
-                                [
-                                    i.get("__labels__", None).issubset(
-                                        motif_edge_labels
-                                    )
-                                    for i in r.values()
-                                ]
-                            ):
+                            r = {
+                                k: v for k, v in r.items() if v.get("__labels__", None).intersection(motif_edge_labels)
+                            }
+                            if len(r) > 0:
                                 filtered_ret.append(r)
 
                         ret = filtered_ret
@@ -498,7 +521,7 @@ class _GrandCypherTransformer(Transformer):
                         if isinstance(r, dict):
                             r = [r]
                         for el in r:
-                            for i, v in el.items():
+                            for i, v in enumerate(el.values()):
                                 r_attr[(i, list(v.get("__labels__", [i]))[0])] = v.get(
                                     entity_attribute, None
                                 )
@@ -837,10 +860,14 @@ class _GrandCypherTransformer(Transformer):
                         match[b] = match[a]
                     else:  # For/else loop
                         # Check if match matches where condition and add
-                        if not self._where_condition or self._where_condition(
-                            match, self._target_graph, self._return_edges
-                        ):
-                            self_matches.append(match)
+                        if self._where_condition:
+                            satisfies_where, where_results = self._where_condition(
+                                match, self._target_graph, self._return_edges
+                            )
+                        else:
+                            where_results = []
+                        if not self._where_condition or satisfies_where:
+                            self_matches.append((match, where_results))
                             self_matche_paths.append(edge_hop_map)
 
                             # Check if limit reached; stop ONLY IF we are not ordering

--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -376,7 +376,7 @@ def _data_path_to_entity_name_attribute(data_path):
 
 class _GrandCypherTransformer(Transformer):
     def __init__(self, target_graph: nx.Graph, limit=None):
-        self._target_graph = nx.MultiDiGraph(target_graph) # target_graph
+        self._target_graph = nx.MultiDiGraph(target_graph)
         self._paths = []
         self._where_condition: CONDITION = None
         self._motif = nx.MultiDiGraph()

--- a/grandcypher/test_queries.py
+++ b/grandcypher/test_queries.py
@@ -1027,7 +1027,7 @@ class TestMultigraphRelations:
         res = GrandCypher(host).run(qry)
         assert res["a.name"] == ["Alice"]
         assert res["b.name"] == ["Bob"]
-        assert res["r.years"] == [{(0, 'colleague'): 3, (1, 'friend'): 5, (2, 'enemy'): None}]   # should return None when attr is missing
+        assert res["r.years"] == [{(0, 'friend'): 5}]
     
     def test_edge_directionality(self):
         host = nx.MultiDiGraph()
@@ -1064,7 +1064,7 @@ class TestMultigraphRelations:
         res = GrandCypher(host).run(qry)
         assert res["a.name"] == ["Alice", "Bob"]
         assert res["b.name"] == ["Charlie", "Charlie"]
-        assert res["r.duration"] == [{(0, 'colleague'): None}, {(0, 'colleague'): 10, (1, 'mentor'): None}]
+        assert res["r.duration"] == [{(0, 'colleague'): None}, {(0, 'colleague'): 10}]
 
         qry = """
         MATCH (a)-[r:colleague]->(b)
@@ -1073,7 +1073,7 @@ class TestMultigraphRelations:
         res = GrandCypher(host).run(qry)
         assert res["a.name"] == ["Alice", "Bob"]
         assert res["b.name"] == ["Charlie", "Charlie"]
-        assert res["r.years"] == [{(0, 'colleague'): 10}, {(0, 'colleague'): None, (1, 'mentor'): 2}]
+        assert res["r.years"] == [{(0, 'colleague'): 10}, {(0, 'colleague'): None}]
 
         qry = """
         MATCH (a)-[r]->(b)
@@ -1085,7 +1085,7 @@ class TestMultigraphRelations:
         assert res["r.__labels__"] == [{(0, 'friend'): {'friend'}}, {(0, 'colleague'): {'colleague'}}, {(0, 'colleague'): {'colleague'}, (1, 'mentor'): {'mentor'}}]
         assert res["r.duration"] == [{(0, 'friend'): None}, {(0, 'colleague'): None}, {(0, 'colleague'): 10, (1, 'mentor'): None}]
 
-    def test_multigraph_single_edge_where(self):
+    def test_multigraph_single_edge_where1(self):
         host = nx.MultiDiGraph()
         host.add_node("a", name="Alice", age=25)
         host.add_node("b", name="Bob", age=30)
@@ -1103,9 +1103,30 @@ class TestMultigraphRelations:
         res = GrandCypher(host).run(qry)
         assert res["a.name"] == ["Alice", "Bob"]
         assert res["b.name"] == ["Bob", "Alice"]
-        assert res["r.__labels__"] == [{(0, 'friend'): {'friend'}}, {(0, 'colleague'): {'colleague'}, (1, 'mentor'): {'mentor'}}]
-        assert res["r.years"] == [{(0, 'friend'): 1}, {(0, 'colleague'): 2, (1, 'mentor'): 4}]
-        assert res["r.friendly"] == [{(0, 'friend'): 'very'}, {(0, 'colleague'): None, (1, 'mentor'): None}]
+        assert res["r.__labels__"] == [{(0, 'friend'): {'friend'}}, {(0, 'colleague'): {'colleague'}}]
+        assert res["r.years"] == [{(0, 'friend'): 1}, {(0, 'colleague'): 2}]
+        assert res["r.friendly"] == [{(0, 'friend'): 'very'}, {(0, 'colleague'): None}]
+
+    def test_multigraph_single_edge_where2(self):
+        host = nx.MultiDiGraph()
+        host.add_node("a", name="Alice", age=25)
+        host.add_node("b", name="Bob", age=30)
+        host.add_edge("a", "b", __labels__={"paid"}, value=20)
+        host.add_edge("a", "b", __labels__={"paid"}, amount=12, date="12th June")
+        host.add_edge("b", "a", __labels__={"paid"}, amount=6)
+        host.add_edge("b", "a", __labels__={"paid"}, value=14)
+        host.add_edge("a", "b", __labels__={"friends"}, years=9)
+        host.add_edge("a", "b", __labels__={"paid"}, amount=40)
+
+        qry = """
+        MATCH (n)-[r:paid]->(m)
+        WHERE r.amount > 12
+        RETURN n.name, m.name, r.amount
+        """
+        res = GrandCypher(host).run(qry)
+        assert res['n.name'] == ['Alice']
+        assert res['m.name'] == ['Bob']
+        assert res['r.amount'] == [{(0, 'paid'): 40}]
 
     def test_multigraph_where_node_attribute(self):
         host = nx.MultiDiGraph()
@@ -1147,7 +1168,7 @@ class TestMultigraphRelations:
         assert res["n.name"] == ["Alice", "Bob"]
         assert res["m.name"] == ["Bob", "Alice"]
         # the second "paid" edge between Bob -> Alice has no "amount" attribute, so it should be None
-        assert res["r.amount"] == [{(0, 'paid'): 12, (1, 'friends'): None, (2, 'paid'): 40}, {(0, 'paid'): 6, (1, 'paid'): None}]
+        assert res["r.amount"] == [{(0, 'paid'): 12, (1, 'paid'): 40}, {(0, 'paid'): 6, (1, 'paid'): None}]
 
     def test_order_by_edge_attribute1(self):
         host = nx.MultiDiGraph()
@@ -1220,7 +1241,7 @@ class TestMultigraphRelations:
         RETURN n.name, m.name, SUM(r.amount)
         """
         res = GrandCypher(host).run(qry)
-        assert res['SUM(r.amount)'] ==  [{'friends': 0, 'paid': 52}, {'paid': 6}]
+        assert res['SUM(r.amount)'] ==  [{'paid': 52}, {'paid': 6}]
 
     def test_multigraph_aggregation_function_avg(self):
         host = nx.MultiDiGraph()


### PR DESCRIPTION
Mentioned in #47, if one edge satisfies a query constraints, ALL edges between the same two nodes are returned. This means the results are correct but they also come with information we didn't ask for:

```python
from grandcypher import GrandCypher
import networkx as nx

host = nx.MultiDiGraph()
host.add_node("a", name="Alice", age=25)
host.add_node("b", name="Bob", age=30)
host.add_edge("a", "b", __labels__={"paid"}, amount=12, date="12th June")
host.add_edge("b", "a", __labels__={"paid"}, amount=6)
host.add_edge("b", "a", __labels__={"paid"}, value=14)
host.add_edge("a", "b", __labels__={"friends"}, years=9)
host.add_edge("a", "b", __labels__={"paid"}, amount=40)

qry = """
MATCH (n)-[r:paid]->(m)
RETURN n.name, m.name, r.amount
"""
res = GrandCypher(host).run(qry)
print(res)

'''
{
   'n.name': ['Alice', 'Bob'], 
   'm.name': ['Bob', 'Alice'], 
   'r.amount': [{(0, 'paid'): 12, (1, 'friends'): None, (2, 'paid'): 40}, {(0, 'paid'): 6, (1, 'paid'): None}]
}
'''
```

This PR should fix this, for both edge labels `[r:paid]` but also `WHERE` conditions:

```python
from grandcypher import GrandCypher
import networkx as nx

host = nx.MultiDiGraph()
host.add_node("a", name="Alice", age=25)
host.add_node("b", name="Bob", age=30)
host.add_edge("a", "b", __labels__={"paid"}, value=20)
host.add_edge("a", "b", __labels__={"paid"}, amount=12, date="12th June")
host.add_edge("b", "a", __labels__={"paid"}, amount=6)
host.add_edge("b", "a", __labels__={"paid"}, value=14)
host.add_edge("a", "b", __labels__={"friends"}, years=9)
host.add_edge("a", "b", __labels__={"paid"}, amount=40)

qry = """
MATCH (n)-[r:paid]->(m)
WHERE r.amount > 12
RETURN n.name, m.name, r.amount
"""
res = GrandCypher(host).run(qry)
print(res)

'''
{
   'n.name': ['Alice'], 
   'm.name': ['Bob'], 
   'r.amount': [{(0, 'paid'): 40}]
}
'''
```