### PR TITLE
Update `lark-parser` dependency to `lark`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 grandiso
-lark-parser
+lark
 networkx

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
     python_requires=">=3.6",
     install_requires=[
         "grandiso",
-        "lark-parser",
+        "lark",
         "networkx",
     ],
 )


### PR DESCRIPTION
Closes #59: lark is maintained, lark-parser is not