### PR TITLE
Fix parsing priority issue with NULL/TRUE/FALSE. Add support for IN Clause.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
+        python-version: [3.9, '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, '3.10', '3.11']
+        python-version: [3.9, '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v2

--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -64,6 +64,7 @@ compound_condition  : condition
                     | compound_condition boolean_arithmetic compound_condition
 
 condition           : entity_id op entity_id_or_value
+                    | entity_id op_list value_list
                     | "not"i condition -> condition_not
 
 ?entity_id_or_value : entity_id
@@ -80,11 +81,11 @@ op                  : "==" -> op_eq
                     | ">="-> op_gte
                     | "<="-> op_lte
                     | "is"i -> op_is
-                    | "in"i -> op_in
                     | "contains"i -> op_contains
                     | "starts with"i -> op_starts_with
                     | "ends with"i -> op_ends_with
 
+op_list             : "in"i -> op_in
 
 
 
@@ -131,6 +132,7 @@ edge_match          : LEFT_ANGLE? "--" RIGHT_ANGLE?
                     | LEFT_ANGLE? "-[" CNAME ":" TYPE "*" MIN_HOP "]-" RIGHT_ANGLE?
                     | LEFT_ANGLE? "-[" CNAME ":" TYPE "*" MIN_HOP  ".." MAX_HOP "]-" RIGHT_ANGLE?
 
+value_list          : "[" [value ("," value)*] "]"
 type_list           : TYPE ( "|" TYPE )*
 
 LEFT_ANGLE          : "<"
@@ -1178,6 +1180,9 @@ class _GrandCypherTransformer(Transformer):
     false = lambda self, _: False
     ESTRING = v_args(inline=True)(eval)
     NUMBER = v_args(inline=True)(eval)
+
+    def value_list(self, items):
+        return list(items)
 
     def op(self, operator):
         return operator

--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -63,10 +63,8 @@ compound_condition  : condition
                     | "(" compound_condition boolean_arithmetic compound_condition ")"
                     | compound_condition boolean_arithmetic compound_condition
 
-condition           : entity_id op entity_id_or_value
-                    | entity_id op_list value_list
-                    | function op entity_id_or_value
-                    | function op_list value_list
+condition           : (entity_id | scalar_function) op entity_id_or_value
+                    | (entity_id | scalar_function) op_list value_list
                     | "not"i condition -> condition_not
 
 ?entity_id_or_value : entity_id
@@ -92,14 +90,14 @@ op_list             : "in"i -> op_in
 
 
 return_clause       : "return"i distinct_return? return_item ("," return_item)*
-return_item         : (entity_id | aggregation_function | entity_id "." attribute_id) ( "AS"i alias )?
+return_item         : (entity_id | aggregation_function | scalar_function | entity_id "." attribute_id) ( "AS"i alias )?
 alias               : CNAME
 
 aggregation_function : AGGREGATE_FUNC "(" entity_id ( "." attribute_id )? ")"
 AGGREGATE_FUNC       : "COUNT" | "SUM" | "AVG" | "MAX" | "MIN"
 attribute_id         : CNAME
 
-function            : "id"i "(" entity_id ")" -> id_function
+scalar_function      : "id"i "(" entity_id ")" -> id_function
 
 distinct_return     : "DISTINCT"i
 limit_clause        : "limit"i NUMBER

--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -65,6 +65,8 @@ compound_condition  : condition
 
 condition           : entity_id op entity_id_or_value
                     | entity_id op_list value_list
+                    | function op entity_id_or_value
+                    | function op_list value_list
                     | "not"i condition -> condition_not
 
 ?entity_id_or_value : entity_id
@@ -96,6 +98,8 @@ alias               : CNAME
 aggregation_function : AGGREGATE_FUNC "(" entity_id ( "." attribute_id )? ")"
 AGGREGATE_FUNC       : "COUNT" | "SUM" | "AVG" | "MAX" | "MIN"
 attribute_id         : CNAME
+
+function            : "id"i "(" entity_id ")" -> id_function
 
 distinct_return     : "DISTINCT"i
 limit_clause        : "limit"i NUMBER
@@ -1180,6 +1184,9 @@ class _GrandCypherTransformer(Transformer):
     false = lambda self, _: False
     ESTRING = v_args(inline=True)(eval)
     NUMBER = v_args(inline=True)(eval)
+
+    def id_function(self, entity_id):
+        return entity_id[0].value
 
     def value_list(self, items):
         return list(items)

--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -68,9 +68,9 @@ condition           : entity_id op entity_id_or_value
 
 ?entity_id_or_value : entity_id
                     | value
-                    | "NULL"i -> null
-                    | "TRUE"i -> true
-                    | "FALSE"i -> false
+                    | NULL -> null
+                    | TRUE -> true
+                    | FALSE -> false
 
 op                  : "==" -> op_eq
                     | "=" -> op_eq
@@ -149,9 +149,13 @@ boolean_arithmetic  : "and"i -> where_and
 key                 : CNAME
 ?value              : ESTRING
                     | NUMBER
-                    | "NULL"i -> null
-                    | "TRUE"i -> true
-                    | "FALSE"i -> false
+                    | NULL -> null
+                    | TRUE -> true
+                    | FALSE -> false
+
+NULL.1                : "NULL"i
+TRUE.1                : "TRUE"i
+FALSE.1               : "FALSE"i
 
 
 %import common.CNAME            -> CNAME

--- a/grandcypher/test_queries.py
+++ b/grandcypher/test_queries.py
@@ -2167,6 +2167,26 @@ class TestMatchWithOrOperatorInRelationships:
         assert res["n1.name"] == ["Bob", "Bob"]
         assert res["n2.name"] == ["Carol", "Derek"]
 
+class TestFunction:
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_id(self, graph_type):
+        host = graph_type()
+        host.add_node(1, name="Ford Prefect")
+        host.add_node(2, name="Arthur Dent")
+        host.add_node(3, name="John Smith")
+        host.add_edge(1, 2)
+        host.add_edge(2, 3)
+
+        qry = """
+        MATCH (A)
+        WHERE id(A) == 1 OR id(A) == 2
+        RETURN A
+        """
+
+        res = GrandCypher(host).run(qry)
+        assert res["A"] == [1, 2]
+
+
 class TestList:
     @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
     def test_in(self, graph_type):
@@ -2179,7 +2199,7 @@ class TestList:
 
         qry = """
         MATCH (A)
-        WHERE A IN [1, 3]
+        WHERE id(A) IN [1, 3]
         RETURN A
         """
 

--- a/grandcypher/test_queries.py
+++ b/grandcypher/test_queries.py
@@ -2180,7 +2180,7 @@ class TestFunction:
         qry = """
         MATCH (A)
         WHERE id(A) == 1 OR id(A) == 2
-        RETURN A
+        RETURN id(A)
         """
 
         res = GrandCypher(host).run(qry)

--- a/grandcypher/test_queries.py
+++ b/grandcypher/test_queries.py
@@ -2166,3 +2166,22 @@ class TestMatchWithOrOperatorInRelationships:
         res = GrandCypher(host).run(qry)
         assert res["n1.name"] == ["Bob", "Bob"]
         assert res["n2.name"] == ["Carol", "Derek"]
+
+class TestList:
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_in(self, graph_type):
+        host = graph_type()
+        host.add_node(1, name="Ford Prefect")
+        host.add_node(2, name="Arthur Dent")
+        host.add_node(3, name="John Smith")
+        host.add_edge(1, 2)
+        host.add_edge(2, 3)
+
+        qry = """
+        MATCH (A)
+        WHERE A IN [1, 3]
+        RETURN A
+        """
+
+        res = GrandCypher(host).run(qry)
+        assert res["A"] == [1, 3]


### PR DESCRIPTION
The recent update of the `lark` parser to the latest version introduced an issue with properly parsing NULL/TRUE/FALSE. It's matching CNAME first.

`lark` has the ability to [set a priority](https://lark-parser.readthedocs.io/en/latest/grammar.html#terminals). This change makes sure the rule for NULL/TRUE/FALSE (case insensitive) is matched before CNAME.

This change also removes deprecated Python builds as I believe this would have been caught by the unit tests otherwise.

Fixes #64. Fixes #65. 