### PR TITLE
Support hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+### **0.14.0** (March 18 2025)
+
+#### Features
+
+-   Support for `hints` in the `run` method (#67)
+
 ### **0.13.0** (February 17 2025)
 
 #### Housekeeping

--- a/docs/Hints.md
+++ b/docs/Hints.md
@@ -1,0 +1,50 @@
+# Hints in GrandCypher
+
+Hints are a powerful feature in GrandCypher that allow you to provide additional guidance to the query engine about which nodes should match specific parts of your query pattern. This can be particularly useful for improving query performance or ensuring specific nodes are included in your results.
+
+## Basic Usage
+
+You can provide hints when running a Cypher query by passing a list of dictionaries to the `run()` method:
+
+```python
+gc = GrandCypher(graph)
+result = gc.run(query, hints=[{"A": 1}, {"B": 2}])
+```
+
+Each dictionary in the hints list maps variable names from your Cypher query to specific node IDs in your graph.
+
+## Why Use Hints?
+
+There are several scenarios where hints are particularly valuable:
+
+1. **Performance Optimization**: When you know exactly which nodes should match certain parts of your pattern, hints can significantly reduce the search space.
+
+2. **Ensuring Specific Matches**: When you want to guarantee that certain nodes are included in your results.
+
+3. **Complex Pattern Matching**: In cases where you want to find patterns that involve specific known nodes along with more general pattern matching.
+
+## How Hints Work
+
+1. When you provide hints, GrandCypher filters the pattern matches based on the node IDs you specify.
+2. Each hint dictionary maps variable names from your Cypher query to specific node IDs in your graph.
+3. The query engine ensures that the specified variables match only the nodes with the given IDs.
+4. Other parts of the pattern that aren't specified in hints are matched normally.
+
+## Best Practices
+
+1. **Use Hints When Possible**: Hints can greatly improve performance, especially in large graphs.
+2. **Variable Names Must Match**: The keys in your hint dictionaries must match variable names in your Cypher query.
+3. **Valid Node IDs**: Make sure the node IDs you specify in hints actually exist in your graph.
+4. **Multiple Hints**: You can provide multiple hints for different variables in the same query.
+
+## Performance Considerations
+
+-   Hints can significantly improve query performance by reducing the search space.
+-   However, overly restrictive hints might cause valid matches to be excluded.
+-   The performance benefit is most noticeable in large graphs where broad pattern matching would be expensive.
+
+## Common Pitfalls
+
+1. **Missing Nodes**: If you provide a hint for a node ID that doesn't exist, you'll get empty results.
+2. **Incompatible Constraints**: If your hints conflict with WHERE clauses or other pattern constraints, you might get unexpected empty results.
+3. **Case Sensitivity**: Make sure variable names in hints exactly match those in your query.

--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -176,7 +176,7 @@ COMMENT: "//" /[^\n]/*
     start="start",
 )
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"
 
 
 _ALPHABET = string.ascii_lowercase + string.digits
@@ -1309,7 +1309,7 @@ class GrandCypher:
         self._transformer = _GrandCypherTransformer(host_graph, limit)
         self._host_graph = host_graph
 
-    def run(self, cypher: str, hints: list[dict] | None = None) -> Dict[str, List]:
+    def run(self, cypher: str, hints: List[dict] | None = None) -> Dict[str, List]:
         """
         Run a cypher query on the host graph.
 

--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -7,7 +7,7 @@ to search in a much larger graph database.
 
 """
 
-from typing import Dict, Hashable, List, Callable, Tuple, Union
+from typing import Dict, Hashable, List, Callable, Optional, Tuple, Union
 from collections import OrderedDict
 import random
 import string
@@ -432,7 +432,7 @@ class _GrandCypherTransformer(Transformer):
         self._limit = limit
         self._skip = 0
         self._max_hop = 100
-        self._hints: list[dict[Hashable, Hashable]] | None = None
+        self._hints: Optional[List[dict[Hashable, Hashable]]] = None
 
     def set_hints(self, hints=None):
         self._hints = hints
@@ -1309,7 +1309,7 @@ class GrandCypher:
         self._transformer = _GrandCypherTransformer(host_graph, limit)
         self._host_graph = host_graph
 
-    def run(self, cypher: str, hints: List[dict] | None = None) -> Dict[str, List]:
+    def run(self, cypher: str, hints: Optional[List[dict]] = None) -> Dict[str, List]:
         """
         Run a cypher query on the host graph.
 

--- a/grandcypher/test_hints.py
+++ b/grandcypher/test_hints.py
@@ -31,6 +31,27 @@ class TestHints:
         assert res == {"A.name": ["Arthur Dent"]}
 
     @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_simple_hint_same_as_full_results(self, graph_type):
+        host = graph_type()
+        host.add_node(1, type="alien", name="Ford Prefect")
+        host.add_node(2, type="human", name="Arthur Dent")
+        host.add_node(3, type="alien", name="Zaphod Beeblebrox")
+        host.add_node(4, type="dog", name="Fido")
+        host.add_edge(1, 4, type="petting")
+        host.add_edge(2, 4, type="petting")
+        host.add_edge(3, 4, type="petting")
+
+        qry = """
+        MATCH (A)-[r]->(B)
+        WHERE A.type <> "human"
+        RETURN A.name
+        """
+
+        gc = GrandCypher(host)
+        res = gc.run(qry, hints=[{"A": 1}, {"A": 3}])
+        assert res == {"A.name": ["Ford Prefect", "Zaphod Beeblebrox"]}
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
     def test_simple_hint(self, graph_type):
         host = graph_type()
         host.add_node(1, type="alien", name="Ford Prefect")
@@ -43,15 +64,14 @@ class TestHints:
 
         qry = """
         MATCH (A)-[r]->(B)
-        WHERE A.type == "human"
+        WHERE A.type <> "human"
         RETURN A.name
         """
 
         gc = GrandCypher(host)
+        res = gc.run(qry, hints=[{"A": 3}])
+        assert res == {"A.name": ["Zaphod Beeblebrox"]}
 
-        # res = gc.run(qry, hints=[{"A": 1}, {"A": 3}])
-        res = gc.run(qry, hints=[{"A": 1}])
-        assert res == {"A.name": ["Ford Prefect", "Zaphod Beeblebrox"]}
-
-        res = gc.run(qry, hints=[{"A": 2}])
-        assert res == {"A.name": ["Arthur Dent"]}
+        # gc = GrandCypher(host)
+        # res = gc.run(qry, hints=[{"A": 1}])
+        # assert res == {"A.name": ["Ford Prefect"]}

--- a/grandcypher/test_hints.py
+++ b/grandcypher/test_hints.py
@@ -2,7 +2,7 @@ import networkx as nx
 import pytest
 
 
-from . import _GrandCypherGrammar, _GrandCypherTransformer, GrandCypher
+from . import GrandCypher
 
 ACCEPTED_GRAPH_TYPES = [nx.MultiDiGraph, nx.DiGraph]
 
@@ -72,6 +72,20 @@ class TestHints:
         res = gc.run(qry, hints=[{"A": 3}])
         assert res == {"A.name": ["Zaphod Beeblebrox"]}
 
-        # gc = GrandCypher(host)
-        # res = gc.run(qry, hints=[{"A": 1}])
-        # assert res == {"A.name": ["Ford Prefect"]}
+        gc = GrandCypher(host)
+        res = gc.run(qry, hints=[{"A": 1}])
+        assert res == {"A.name": ["Ford Prefect"]}
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_ER_hints(self, graph_type):
+        """
+        Test random graphs
+        """
+        host = nx.fast_gnp_random_graph(100, 0.1, directed=nx.is_directed(graph_type()))
+        hints = [{"A": 1}]
+        gc = GrandCypher(host)
+        qry = """
+        MATCH (A)-[r]->(B) RETURN A
+        """
+        res = gc.run(qry, hints=hints)
+        assert all(r == 1 for r in res["A"])

--- a/grandcypher/test_hints.py
+++ b/grandcypher/test_hints.py
@@ -1,0 +1,57 @@
+import networkx as nx
+import pytest
+
+
+from . import _GrandCypherGrammar, _GrandCypherTransformer, GrandCypher
+
+ACCEPTED_GRAPH_TYPES = [nx.MultiDiGraph, nx.DiGraph]
+
+
+class TestHints:
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_no_hints(self, graph_type):
+        host = graph_type()
+        host.add_node(1, type="alien", name="Ford Prefect")
+        host.add_node(2, type="human", name="Arthur Dent")
+        host.add_node(3, type="alien", name="Zaphod Beeblebrox")
+        host.add_node(4, type="dog", name="Fido")
+        host.add_edge(1, 4, type="petting")
+        host.add_edge(2, 4, type="petting")
+        host.add_edge(3, 4, type="petting")
+
+        qry = """
+        MATCH (A)-[r]->(B)
+        WHERE A.type == "human"
+        RETURN A.name
+        """
+
+        gc = GrandCypher(host)
+
+        res = gc.run(qry)
+        assert res == {"A.name": ["Arthur Dent"]}
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_simple_hint(self, graph_type):
+        host = graph_type()
+        host.add_node(1, type="alien", name="Ford Prefect")
+        host.add_node(2, type="human", name="Arthur Dent")
+        host.add_node(3, type="alien", name="Zaphod Beeblebrox")
+        host.add_node(4, type="dog", name="Fido")
+        host.add_edge(1, 4, type="petting")
+        host.add_edge(2, 4, type="petting")
+        host.add_edge(3, 4, type="petting")
+
+        qry = """
+        MATCH (A)-[r]->(B)
+        WHERE A.type == "human"
+        RETURN A.name
+        """
+
+        gc = GrandCypher(host)
+
+        # res = gc.run(qry, hints=[{"A": 1}, {"A": 3}])
+        res = gc.run(qry, hints=[{"A": 1}])
+        assert res == {"A.name": ["Ford Prefect", "Zaphod Beeblebrox"]}
+
+        res = gc.run(qry, hints=[{"A": 2}])
+        assert res == {"A.name": ["Arthur Dent"]}

--- a/grandcypher/test_hints.py
+++ b/grandcypher/test_hints.py
@@ -89,3 +89,30 @@ class TestHints:
         """
         res = gc.run(qry, hints=hints)
         assert all(r == 1 for r in res["A"])
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_multiple_nodes_hinted(self, graph_type):
+        """
+        Test the case where multiple nodes are hinted
+        """
+        host = graph_type()
+        host.add_node(1, name="Home")
+        host.add_node(2, name="Work")
+        host.add_node(3, name="School")
+        host.add_node(4, name="Library")
+        host.add_node(5, name="Park")
+        host.add_edge(1, 2)
+        host.add_edge(1, 3)
+        host.add_edge(2, 4)
+        host.add_edge(3, 4)
+        host.add_edge(4, 5)
+        host.add_edge(5, 1)
+
+        qry = """
+        MATCH (A)-[r]->(B)
+        RETURN A.name, B.name
+        """
+
+        gc = GrandCypher(host)
+        res = gc.run(qry, hints=[{"A": 1, "B": 2}, {"A": 3, "B": 4}])
+        assert res == {"A.name": ["Home", "School"], "B.name": ["Work", "Library"]}

--- a/grandcypher/test_hints.py
+++ b/grandcypher/test_hints.py
@@ -8,6 +8,7 @@ ACCEPTED_GRAPH_TYPES = [nx.MultiDiGraph, nx.DiGraph]
 
 
 class TestHints:
+    @pytest.mark.benchmark
     @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
     def test_no_hints(self, graph_type):
         host = graph_type()
@@ -30,6 +31,7 @@ class TestHints:
         res = gc.run(qry)
         assert res == {"A.name": ["Arthur Dent"]}
 
+    @pytest.mark.benchmark
     @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
     def test_simple_hint_same_as_full_results(self, graph_type):
         host = graph_type()
@@ -90,6 +92,7 @@ class TestHints:
         res = gc.run(qry, hints=hints)
         assert all(r == 1 for r in res["A"])
 
+    @pytest.mark.benchmark
     @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
     def test_multiple_nodes_hinted(self, graph_type):
         """

--- a/grandcypher/test_queries.py
+++ b/grandcypher/test_queries.py
@@ -6,39 +6,8 @@ from . import _GrandCypherGrammar, _GrandCypherTransformer, GrandCypher
 
 ACCEPTED_GRAPH_TYPES = [nx.MultiDiGraph, nx.DiGraph]
 
+
 class TestWorking:
-    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
-    def test_simple_structural_match(self, graph_type):
-        tree = _GrandCypherGrammar.parse(
-            """
-        MATCH (A)-[B]->(C)
-        RETURN A
-        """
-        )
-        host = graph_type()
-        host.add_edge("x", "y")
-        host.add_edge("y", "z")
-        gct = _GrandCypherTransformer(host)
-        gct.transform(tree)
-        assert len(gct._get_true_matches()) == 2
-
-    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
-    def test_simple_structural_match_returns_nodes(self, graph_type):
-        tree = _GrandCypherGrammar.parse(
-            """
-        MATCH (A)-[B]->(C)
-        RETURN A
-        """
-        )
-        host = graph_type()
-        host.add_edge("x", "y")
-        host.add_edge("y", "z")
-        gct = _GrandCypherTransformer(host)
-        gct.transform(tree)
-        returns = gct.returns()
-        assert "A" in returns
-        assert len(returns["A"]) == 2
-
     @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
     def test_simple_structural_match_returns_node_attributes(self, graph_type):
         tree = _GrandCypherGrammar.parse(
@@ -650,8 +619,12 @@ class TestDistinct:
         """
         res = GrandCypher(host).run(qry)
         assert len(res["n.name"]) == 4  # should return "Alice" and "Bob" only once
-        assert "Alice" in res["n.name"] and "Bob" in res["n.name"] and "Carol" in res["n.name"] and "Greg" in res["n.name"]
-
+        assert (
+            "Alice" in res["n.name"]
+            and "Bob" in res["n.name"]
+            and "Carol" in res["n.name"]
+            and "Greg" in res["n.name"]
+        )
 
     @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
     def test_distinct_with_relationships(self, graph_type):
@@ -670,7 +643,6 @@ class TestDistinct:
         assert len(res["n.name"]) == 1  # should return "Alice" only once
         assert res["n.name"] == ["Alice"]
 
-
     @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
     def test_distinct_with_limit_and_skip(self, graph_type):
         host = graph_type()
@@ -685,7 +657,6 @@ class TestDistinct:
         res = GrandCypher(host).run(qry)
         assert len(res["n.name"]) == 1  # only one name should be returned
         assert res["n.name"] == ["Bob"]  # assuming alphabetical order
-
 
     @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
     def test_distinct_on_complex_graph(self, graph_type):
@@ -703,9 +674,17 @@ class TestDistinct:
         RETURN DISTINCT n.name, m.name
         """
         res = GrandCypher(host).run(qry)
-        assert len(res["n.name"]) == 3  # should account for paths without considering duplicate names
-        assert "Alice" in res["n.name"] and "Bob" in res["n.name"] and "Carol" in res["n.name"]
-        assert len(res["m.name"]) == 3  # should account for paths without considering duplicate names
+        assert (
+            len(res["n.name"]) == 3
+        )  # should account for paths without considering duplicate names
+        assert (
+            "Alice" in res["n.name"]
+            and "Bob" in res["n.name"]
+            and "Carol" in res["n.name"]
+        )
+        assert (
+            len(res["m.name"]) == 3
+        )  # should account for paths without considering duplicate names
 
     @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
     def test_distinct_with_attributes(self, graph_type):
@@ -734,7 +713,7 @@ class TestOrderBy:
 
         qry = """
         MATCH (n)
-        RETURN n.name 
+        RETURN n.name
         ORDER BY n.age ASC
         """
         res = GrandCypher(host).run(qry)
@@ -749,7 +728,7 @@ class TestOrderBy:
 
         qry = """
         MATCH (n)
-        RETURN n.name 
+        RETURN n.name
         ORDER BY n.age DESC
         """
         res = GrandCypher(host).run(qry)
@@ -764,7 +743,7 @@ class TestOrderBy:
 
         qry = """
         MATCH (n)
-        RETURN n.name 
+        RETURN n.name
         ORDER BY n.age
         """
         res = GrandCypher(host).run(qry)
@@ -785,9 +764,9 @@ class TestOrderBy:
         ORDER BY r.value ASC
         """
         res = GrandCypher(host).run(qry)
-        assert res['n.name'] == ['Alice', 'Alice', 'Bob']
-        assert res['m.name'] == ['Carol', 'Bob', 'Alice']
-        assert res['r.value'] == [{(0, 'paid'): 4}, {(0, 'paid'): 9}, {(0, 'paid'): 14}]
+        assert res["n.name"] == ["Alice", "Alice", "Bob"]
+        assert res["m.name"] == ["Carol", "Bob", "Alice"]
+        assert res["r.value"] == [{(0, "paid"): 4}, {(0, "paid"): 9}, {(0, "paid"): 14}]
 
         qry = """
         MATCH (n)-[r]->()
@@ -795,16 +774,17 @@ class TestOrderBy:
         ORDER BY r.value DESC
         """
         res = GrandCypher(host).run(qry)
-        assert res['n.name'] == ['Bob', 'Alice', 'Alice']
-        assert res['r.value'] == [{(0, 'paid'): 14}, {(0, 'paid'): 9}, {(0, 'paid'): 4}]
+        assert res["n.name"] == ["Bob", "Alice", "Alice"]
+        assert res["r.value"] == [{(0, "paid"): 14}, {(0, "paid"): 9}, {(0, "paid"): 4}]
 
-        
     def test_order_by_edge_attribute2(self):
         host = nx.DiGraph()
         host.add_node("a", name="Alice", age=25)
         host.add_node("b", name="Bob", age=30)
         host.add_node("c", name="Carol", age=20)
-        host.add_edge("b", "a", __labels__={"paid"}, amount=14) # different attribute name
+        host.add_edge(
+            "b", "a", __labels__={"paid"}, amount=14
+        )  # different attribute name
         host.add_edge("a", "b", __labels__={"paid"}, value=9)
         host.add_edge("c", "b", __labels__={"paid"}, value=980)
         host.add_edge("b", "c", __labels__={"paid"}, value=11)
@@ -815,14 +795,14 @@ class TestOrderBy:
         ORDER BY r.value ASC
         """
         res = GrandCypher(host).run(qry)
-        assert res['n.name'] == ['Bob', 'Alice', 'Bob', 'Carol']
-        assert res['r.value'] == [
-            {(0, 'paid'): None}, # None for the different attribute edge
-            {(0, 'paid'): 9},    # within edges, the attributes are ordered
-            {(0, 'paid'): 11}, 
-            {(0, 'paid'): 980}
+        assert res["n.name"] == ["Bob", "Alice", "Bob", "Carol"]
+        assert res["r.value"] == [
+            {(0, "paid"): None},  # None for the different attribute edge
+            {(0, "paid"): 9},  # within edges, the attributes are ordered
+            {(0, "paid"): 11},
+            {(0, "paid"): 980},
         ]
-        assert res['m.name'] == ['Alice', 'Bob', 'Carol', 'Bob']
+        assert res["m.name"] == ["Alice", "Bob", "Carol", "Bob"]
 
     def test_order_by_aggregation_function(self):
         host = nx.MultiDiGraph()
@@ -841,8 +821,8 @@ class TestOrderBy:
         ORDER BY SUM(r.value) ASC
         """
         res = GrandCypher(host).run(qry)
-        assert res['n.name'] == ['Bob', 'Alice']
-        assert res['SUM(r.value)'] == [{'paid': 14}, {'paid': 49}]
+        assert res["n.name"] == ["Bob", "Alice"]
+        assert res["SUM(r.value)"] == [{"paid": 14}, {"paid": 49}]
 
         # AVG
         qry = """
@@ -851,9 +831,12 @@ class TestOrderBy:
         ORDER BY AVG(r.value) DESC
         """
         res = GrandCypher(host).run(qry)
-        assert res['n.name'] == ['Alice', 'Bob']
-        assert res['AVG(r.value)'] == [{'paid': 16.333333333333332}, {'paid': 14.0}]
-        assert res['r.value'] == [{(0, 'paid'): 9, (1, 'paid'): None, (2, 'paid'): 40}, {(0, 'paid'): 14}]
+        assert res["n.name"] == ["Alice", "Bob"]
+        assert res["AVG(r.value)"] == [{"paid": 16.333333333333332}, {"paid": 14.0}]
+        assert res["r.value"] == [
+            {(0, "paid"): 9, (1, "paid"): None, (2, "paid"): 40},
+            {(0, "paid"): 14},
+        ]
 
         # MIN, MAX, and COUNT
         qry = """
@@ -862,11 +845,10 @@ class TestOrderBy:
         ORDER BY MAX(r.value) DESC
         """
         res = GrandCypher(host).run(qry)
-        assert res['n.name'] == ['Alice', 'Bob']
-        assert res['MIN(r.value)'] == [{'paid': 9}, {'paid': 14}]
-        assert res['MAX(r.value)'] == [{'paid': 40}, {'paid': 14}]
-        assert res['COUNT(r.value)'] == [{'paid': 3}, {'paid': 1}]
-
+        assert res["n.name"] == ["Alice", "Bob"]
+        assert res["MIN(r.value)"] == [{"paid": 9}, {"paid": 14}]
+        assert res["MAX(r.value)"] == [{"paid": 40}, {"paid": 14}]
+        assert res["COUNT(r.value)"] == [{"paid": 3}, {"paid": 1}]
 
     @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
     def test_order_by_aggregation_fails_if_not_requested_in_return(self, graph_type):
@@ -887,7 +869,6 @@ class TestOrderBy:
         with pytest.raises(Exception):
             GrandCypher(host).run(qry)
 
-
     @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
     def test_order_by_multiple_fields(self, graph_type):
         host = graph_type()
@@ -898,7 +879,7 @@ class TestOrderBy:
 
         qry = """
         MATCH (n)
-        RETURN n.name 
+        RETURN n.name
         ORDER BY n.age ASC, n.name DESC
         """
         res = GrandCypher(host).run(qry)
@@ -914,7 +895,7 @@ class TestOrderBy:
 
         qry = """
         MATCH (n)
-        RETURN n.name 
+        RETURN n.name
         ORDER BY n.age ASC LIMIT 2
         """
         res = GrandCypher(host).run(qry)
@@ -929,7 +910,7 @@ class TestOrderBy:
 
         qry = """
         MATCH (n)
-        RETURN n.name 
+        RETURN n.name
         ORDER BY n.age ASC SKIP 1
         """
         res = GrandCypher(host).run(qry)
@@ -951,7 +932,7 @@ class TestOrderBy:
         """
         res = GrandCypher(host).run(qry)
         # Distinct names, ordered by age where available
-        assert res["n.name"] == ['Greg', 'Bob', 'Alice', 'Carol']
+        assert res["n.name"] == ["Greg", "Bob", "Alice", "Carol"]
         assert res["n.age"] == [32, 30, 25, 25]
 
     @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
@@ -1010,8 +991,8 @@ class TestMultigraphRelations:
         RETURN n.name, m.name
         """
         res = GrandCypher(host).run(qry)
-        assert res["n.name"] == ['Alice', 'Charlie', 'Diana']
-        assert res["m.name"] == ['Bob', 'Diana', 'Alice']
+        assert res["n.name"] == ["Alice", "Charlie", "Diana"]
+        assert res["m.name"] == ["Bob", "Diana", "Alice"]
 
     def test_multiple_edges_specific_attribute(self):
         host = nx.MultiDiGraph()
@@ -1028,8 +1009,8 @@ class TestMultigraphRelations:
         res = GrandCypher(host).run(qry)
         assert res["a.name"] == ["Alice"]
         assert res["b.name"] == ["Bob"]
-        assert res["r.years"] == [{(0, 'friend'): 5}]
-    
+        assert res["r.years"] == [{(0, "friend"): 5}]
+
     def test_edge_directionality(self):
         host = nx.MultiDiGraph()
         host.add_node("a", name="Alice", age=25)
@@ -1045,8 +1026,14 @@ class TestMultigraphRelations:
         res = GrandCypher(host).run(qry)
         assert res["a.name"] == ["Alice", "Bob"]
         assert res["b.name"] == ["Bob", "Alice"]
-        assert res["r.__labels__"] == [{(0, 'friend'): {'friend'}}, {(0, 'colleague'): {'colleague'}, (1, 'mentor'): {'mentor'}}]
-        assert res["r.years"] == [{(0, 'friend'): 1}, {(0, 'colleague'): 2, (1, 'mentor'): 4}]
+        assert res["r.__labels__"] == [
+            {(0, "friend"): {"friend"}},
+            {(0, "colleague"): {"colleague"}, (1, "mentor"): {"mentor"}},
+        ]
+        assert res["r.years"] == [
+            {(0, "friend"): 1},
+            {(0, "colleague"): 2, (1, "mentor"): 4},
+        ]
 
     def test_query_with_missing_edge_attribute(self):
         host = nx.MultiDiGraph()
@@ -1065,7 +1052,7 @@ class TestMultigraphRelations:
         res = GrandCypher(host).run(qry)
         assert res["a.name"] == ["Alice", "Bob"]
         assert res["b.name"] == ["Charlie", "Charlie"]
-        assert res["r.duration"] == [{(0, 'colleague'): None}, {(0, 'colleague'): 10}]
+        assert res["r.duration"] == [{(0, "colleague"): None}, {(0, "colleague"): 10}]
 
         qry = """
         MATCH (a)-[r:colleague]->(b)
@@ -1074,17 +1061,25 @@ class TestMultigraphRelations:
         res = GrandCypher(host).run(qry)
         assert res["a.name"] == ["Alice", "Bob"]
         assert res["b.name"] == ["Charlie", "Charlie"]
-        assert res["r.years"] == [{(0, 'colleague'): 10}, {(0, 'colleague'): None}]
+        assert res["r.years"] == [{(0, "colleague"): 10}, {(0, "colleague"): None}]
 
         qry = """
         MATCH (a)-[r]->(b)
         RETURN a.name, b.name, r.__labels__, r.duration
         """
         res = GrandCypher(host).run(qry)
-        assert res["a.name"] == ['Alice', 'Alice', 'Bob']
-        assert res["b.name"] == ['Bob', 'Charlie', 'Charlie']
-        assert res["r.__labels__"] == [{(0, 'friend'): {'friend'}}, {(0, 'colleague'): {'colleague'}}, {(0, 'colleague'): {'colleague'}, (1, 'mentor'): {'mentor'}}]
-        assert res["r.duration"] == [{(0, 'friend'): None}, {(0, 'colleague'): None}, {(0, 'colleague'): 10, (1, 'mentor'): None}]
+        assert res["a.name"] == ["Alice", "Alice", "Bob"]
+        assert res["b.name"] == ["Bob", "Charlie", "Charlie"]
+        assert res["r.__labels__"] == [
+            {(0, "friend"): {"friend"}},
+            {(0, "colleague"): {"colleague"}},
+            {(0, "colleague"): {"colleague"}, (1, "mentor"): {"mentor"}},
+        ]
+        assert res["r.duration"] == [
+            {(0, "friend"): None},
+            {(0, "colleague"): None},
+            {(0, "colleague"): 10, (1, "mentor"): None},
+        ]
 
     def test_multigraph_single_edge_where1(self):
         host = nx.MultiDiGraph()
@@ -1104,9 +1099,12 @@ class TestMultigraphRelations:
         res = GrandCypher(host).run(qry)
         assert res["a.name"] == ["Alice", "Bob"]
         assert res["b.name"] == ["Bob", "Alice"]
-        assert res["r.__labels__"] == [{(0, 'friend'): {'friend'}}, {(0, 'colleague'): {'colleague'}}]
-        assert res["r.years"] == [{(0, 'friend'): 1}, {(0, 'colleague'): 2}]
-        assert res["r.friendly"] == [{(0, 'friend'): 'very'}, {(0, 'colleague'): None}]
+        assert res["r.__labels__"] == [
+            {(0, "friend"): {"friend"}},
+            {(0, "colleague"): {"colleague"}},
+        ]
+        assert res["r.years"] == [{(0, "friend"): 1}, {(0, "colleague"): 2}]
+        assert res["r.friendly"] == [{(0, "friend"): "very"}, {(0, "colleague"): None}]
 
     def test_multigraph_single_edge_where2(self):
         host = nx.MultiDiGraph()
@@ -1125,9 +1123,9 @@ class TestMultigraphRelations:
         RETURN n.name, m.name, r.amount
         """
         res = GrandCypher(host).run(qry)
-        assert res['n.name'] == ['Alice']
-        assert res['m.name'] == ['Bob']
-        assert res['r.amount'] == [{(0, 'paid'): 40}]
+        assert res["n.name"] == ["Alice"]
+        assert res["m.name"] == ["Bob"]
+        assert res["r.amount"] == [{(0, "paid"): 40}]
 
     def test_multigraph_where_node_attribute(self):
         host = nx.MultiDiGraph()
@@ -1147,9 +1145,9 @@ class TestMultigraphRelations:
         res = GrandCypher(host).run(qry)
         assert res["a.name"] == ["Alice"]
         assert res["b.name"] == ["Bob"]
-        assert res["r.__labels__"] == [{(0, 'friend'): {'friend'}}]
-        assert res["r.years"] == [{(0, 'friend'): 1}]
-        assert res["r.friendly"] == [{(0, 'friend'): 'very'}]
+        assert res["r.__labels__"] == [{(0, "friend"): {"friend"}}]
+        assert res["r.years"] == [{(0, "friend"): 1}]
+        assert res["r.friendly"] == [{(0, "friend"): "very"}]
 
     def test_multigraph_multiple_same_edge_labels(self):
         host = nx.MultiDiGraph()
@@ -1169,7 +1167,10 @@ class TestMultigraphRelations:
         assert res["n.name"] == ["Alice", "Bob"]
         assert res["m.name"] == ["Bob", "Alice"]
         # the second "paid" edge between Bob -> Alice has no "amount" attribute, so it should be None
-        assert res["r.amount"] == [{(0, 'paid'): 12, (1, 'paid'): 40}, {(0, 'paid'): 6, (1, 'paid'): None}]
+        assert res["r.amount"] == [
+            {(0, "paid"): 12, (1, "paid"): 40},
+            {(0, "paid"): 6, (1, "paid"): None},
+        ]
 
     def test_order_by_edge_attribute1(self):
         host = nx.MultiDiGraph()
@@ -1186,8 +1187,8 @@ class TestMultigraphRelations:
         ORDER BY r.value ASC
         """
         res = GrandCypher(host).run(qry)
-        assert res['n.name'] == ['Alice', 'Bob']
-        assert res['r.value'] == [{(0, 'paid'): 9, (1, 'paid'): 40}, {(0, 'paid'): 14}]
+        assert res["n.name"] == ["Alice", "Bob"]
+        assert res["r.value"] == [{(0, "paid"): 9, (1, "paid"): 40}, {(0, "paid"): 14}]
 
         qry = """
         MATCH (n)-[r]->()
@@ -1195,22 +1196,24 @@ class TestMultigraphRelations:
         ORDER BY r.value DESC
         """
         res = GrandCypher(host).run(qry)
-        assert res['n.name'] == ['Alice', 'Bob']
-        assert res['r.value'] == [{(1, 'paid'): 40, (0, 'paid'): 9}, {(0, 'paid'): 14}]
+        assert res["n.name"] == ["Alice", "Bob"]
+        assert res["r.value"] == [{(1, "paid"): 40, (0, "paid"): 9}, {(0, "paid"): 14}]
 
     def test_order_by_edge_attribute2(self):
         host = nx.MultiDiGraph()
         host.add_node("a", name="Alice", age=25)
         host.add_node("b", name="Bob", age=30)
         host.add_node("c", name="Carol", age=20)
-        host.add_edge("b", "a", __labels__={"paid"}, amount=14) # different attribute name
+        host.add_edge(
+            "b", "a", __labels__={"paid"}, amount=14
+        )  # different attribute name
         host.add_edge("a", "b", __labels__={"paid"}, value=9)
         host.add_edge("c", "b", __labels__={"paid"}, value=980)
         host.add_edge("c", "b", __labels__={"paid"}, value=4)
         host.add_edge("b", "c", __labels__={"paid"}, value=11)
         host.add_edge("a", "b", __labels__={"paid"}, value=40)
         host.add_edge("b", "a", __labels__={"paid"}, value=14)  # duplicate edge
-        host.add_edge("a", "b", __labels__={"paid"}, value=9)   # duplicate edge
+        host.add_edge("a", "b", __labels__={"paid"}, value=9)  # duplicate edge
         host.add_edge("a", "b", __labels__={"paid"}, value=40)  # duplicate edge
 
         qry = """
@@ -1219,13 +1222,19 @@ class TestMultigraphRelations:
         ORDER BY r.value ASC
         """
         res = GrandCypher(host).run(qry)
-        assert res['r.value'] == [
-            {(0, 'paid'): None, (1, 'paid'): 14}, # None for the different attribute edge
-            {(1, 'paid'): 4, (0, 'paid'): 980},   # within edges, the attributes are ordered
-            {(0, 'paid'): 9, (2, 'paid'): 9, (1, 'paid'): 40, (3, 'paid'): 40}, 
-            {(0, 'paid'): 11}
+        assert res["r.value"] == [
+            {
+                (0, "paid"): None,
+                (1, "paid"): 14,
+            },  # None for the different attribute edge
+            {
+                (1, "paid"): 4,
+                (0, "paid"): 980,
+            },  # within edges, the attributes are ordered
+            {(0, "paid"): 9, (2, "paid"): 9, (1, "paid"): 40, (3, "paid"): 40},
+            {(0, "paid"): 11},
         ]
-        assert res['m.name'] == ['Alice', 'Bob', 'Bob', 'Carol']
+        assert res["m.name"] == ["Alice", "Bob", "Bob", "Carol"]
 
     def test_order_by_edge_attribute1(self):
         host = nx.MultiDiGraph()
@@ -1242,8 +1251,8 @@ class TestMultigraphRelations:
         ORDER BY r.value ASC
         """
         res = GrandCypher(host).run(qry)
-        assert res['n.name'] == ['Alice', 'Bob']
-        assert res['r.value'] == [{(0, 'paid'): 9, (1, 'paid'): 40}, {(0, 'paid'): 14}]
+        assert res["n.name"] == ["Alice", "Bob"]
+        assert res["r.value"] == [{(0, "paid"): 9, (1, "paid"): 40}, {(0, "paid"): 14}]
 
         qry = """
         MATCH (n)-[r]->()
@@ -1251,22 +1260,24 @@ class TestMultigraphRelations:
         ORDER BY r.value DESC
         """
         res = GrandCypher(host).run(qry)
-        assert res['n.name'] == ['Alice', 'Bob']
-        assert res['r.value'] == [{(1, 'paid'): 40, (0, 'paid'): 9}, {(0, 'paid'): 14}]
+        assert res["n.name"] == ["Alice", "Bob"]
+        assert res["r.value"] == [{(1, "paid"): 40, (0, "paid"): 9}, {(0, "paid"): 14}]
 
     def test_order_by_edge_attribute2(self):
         host = nx.MultiDiGraph()
         host.add_node("a", name="Alice", age=25)
         host.add_node("b", name="Bob", age=30)
         host.add_node("c", name="Carol", age=20)
-        host.add_edge("b", "a", __labels__={"paid"}, amount=14) # different attribute name
+        host.add_edge(
+            "b", "a", __labels__={"paid"}, amount=14
+        )  # different attribute name
         host.add_edge("a", "b", __labels__={"paid"}, value=9)
         host.add_edge("c", "b", __labels__={"paid"}, value=980)
         host.add_edge("c", "b", __labels__={"paid"}, value=4)
         host.add_edge("b", "c", __labels__={"paid"}, value=11)
         host.add_edge("a", "b", __labels__={"paid"}, value=40)
         host.add_edge("b", "a", __labels__={"paid"}, value=14)  # duplicate edge
-        host.add_edge("a", "b", __labels__={"paid"}, value=9)   # duplicate edge
+        host.add_edge("a", "b", __labels__={"paid"}, value=9)  # duplicate edge
         host.add_edge("a", "b", __labels__={"paid"}, value=40)  # duplicate edge
 
         qry = """
@@ -1275,13 +1286,19 @@ class TestMultigraphRelations:
         ORDER BY r.value ASC
         """
         res = GrandCypher(host).run(qry)
-        assert res['r.value'] == [
-            {(0, 'paid'): None, (1, 'paid'): 14}, # None for the different attribute edge
-            {(1, 'paid'): 4, (0, 'paid'): 980},   # within edges, the attributes are ordered
-            {(0, 'paid'): 9, (2, 'paid'): 9, (1, 'paid'): 40, (3, 'paid'): 40}, 
-            {(0, 'paid'): 11}
+        assert res["r.value"] == [
+            {
+                (0, "paid"): None,
+                (1, "paid"): 14,
+            },  # None for the different attribute edge
+            {
+                (1, "paid"): 4,
+                (0, "paid"): 980,
+            },  # within edges, the attributes are ordered
+            {(0, "paid"): 9, (2, "paid"): 9, (1, "paid"): 40, (3, "paid"): 40},
+            {(0, "paid"): 11},
         ]
-        assert res['m.name'] == ['Alice', 'Bob', 'Bob', 'Carol']
+        assert res["m.name"] == ["Alice", "Bob", "Bob", "Carol"]
 
     def test_multigraph_aggregation_function_sum(self):
         host = nx.MultiDiGraph()
@@ -1298,7 +1315,7 @@ class TestMultigraphRelations:
         RETURN n.name, m.name, SUM(r.amount)
         """
         res = GrandCypher(host).run(qry)
-        assert res['SUM(r.amount)'] ==  [{'paid': 52}, {'paid': 6}]
+        assert res["SUM(r.amount)"] == [{"paid": 52}, {"paid": 6}]
 
     def test_multigraph_aggregation_function_avg(self):
         host = nx.MultiDiGraph()
@@ -1313,7 +1330,7 @@ class TestMultigraphRelations:
         RETURN n.name, m.name, AVG(r.amount)
         """
         res = GrandCypher(host).run(qry)
-        assert res["AVG(r.amount)"] == [{'paid': 26}, {'paid': 6}]
+        assert res["AVG(r.amount)"] == [{"paid": 26}, {"paid": 6}]
 
     def test_multigraph_aggregation_function_min(self):
         host = nx.MultiDiGraph()
@@ -1329,7 +1346,7 @@ class TestMultigraphRelations:
         RETURN n.name, m.name, MIN(r.amount)
         """
         res = GrandCypher(host).run(qry)
-        assert res["MIN(r.amount)"] == [{'paid': 12}, {'paid': 6}]
+        assert res["MIN(r.amount)"] == [{"paid": 12}, {"paid": 6}]
 
     def test_multigraph_aggregation_function_max(self):
         host = nx.MultiDiGraph()
@@ -1346,14 +1363,14 @@ class TestMultigraphRelations:
         RETURN n.name, m.name, MAX(r.amount)
         """
         res = GrandCypher(host).run(qry)
-        assert res["MAX(r.amount)"] == [{'paid': 40}, {'paid': 6}]
+        assert res["MAX(r.amount)"] == [{"paid": 40}, {"paid": 6}]
 
         qry = """
         MATCH (n)-[r:owes]->(m)
         RETURN n.name, m.name, MAX(r.amount)
         """
         res = GrandCypher(host).run(qry)
-        assert res["MAX(r.amount)"] == [{'owes': 39}]
+        assert res["MAX(r.amount)"] == [{"owes": 39}]
 
     def test_multigraph_aggregation_function_count(self):
         host = nx.MultiDiGraph()
@@ -1370,7 +1387,7 @@ class TestMultigraphRelations:
         RETURN n.name, m.name, COUNT(r.amount)
         """
         res = GrandCypher(host).run(qry)
-        assert res["COUNT(r.amount)"] == [{'paid': 2}, {'paid': 1}]
+        assert res["COUNT(r.amount)"] == [{"paid": 2}, {"paid": 1}]
 
     def test_multigraph_multiple_aggregation_functions(self):
         host = nx.MultiDiGraph()
@@ -1387,8 +1404,8 @@ class TestMultigraphRelations:
         RETURN n.name, m.name, COUNT(r.amount), SUM(r.amount)
         """
         res = GrandCypher(host).run(qry)
-        assert res["COUNT(r.amount)"] == [{'paid': 2}, {'paid': 1}]
-        assert res["SUM(r.amount)"] == [{'paid': 52}, {'paid': 6}]
+        assert res["COUNT(r.amount)"] == [{"paid": 2}, {"paid": 1}]
+        assert res["SUM(r.amount)"] == [{"paid": 52}, {"paid": 6}]
 
 
 class TestAlias:
@@ -1423,7 +1440,11 @@ class TestAlias:
         assert res["A"] == ["x", "y", "z"]
         assert res["B"] == ["y", "z", "x"]
         assert graph_type in ACCEPTED_GRAPH_TYPES
-        assert res["arr"] == [[{0: {'bar': '1'}}], [{0: {'bar': '2'}}], [{0: {'bar': '3'}}]]
+        assert res["arr"] == [
+            [{0: {"bar": "1"}}],
+            [{0: {"bar": "2"}}],
+            [{0: {"bar": "3"}}],
+        ]
 
     def test_alias_with_order_by(self):
         host = nx.MultiDiGraph()
@@ -1441,13 +1462,13 @@ class TestAlias:
         ORDER BY average ASC
         """
         res = GrandCypher(host).run(qry)
-        assert res["n.name"] == ['Bob', 'Alice']
-        assert res["m.name"] == ['Alice', 'Bob']
-        assert res['r.value'] == [
-            {(0, 'paid'): 14}, 
-            {(0, 'paid'): 9, (1, 'paid'): None, (2, 'paid'): 40}
+        assert res["n.name"] == ["Bob", "Alice"]
+        assert res["m.name"] == ["Alice", "Bob"]
+        assert res["r.value"] == [
+            {(0, "paid"): 14},
+            {(0, "paid"): 9, (1, "paid"): None, (2, "paid"): 40},
         ]
-        assert res["average"] == [{'paid': 14.0}, {'paid': 16.333333333333332}]
+        assert res["average"] == [{"paid": 14.0}, {"paid": 16.333333333333332}]
 
         qry = """
         MATCH (n)-[r]->(m)
@@ -1455,12 +1476,12 @@ class TestAlias:
         ORDER BY myvalue ASC
         """
         res = GrandCypher(host).run(qry)
-        assert res["n.name"] == ['Alice', 'Bob']
-        assert res["m.name"] == ['Bob', 'Alice']
-        assert res['total'] == [{'paid': 16.333333333333332}, {'paid': 14.0}]
+        assert res["n.name"] == ["Alice", "Bob"]
+        assert res["m.name"] == ["Bob", "Alice"]
+        assert res["total"] == [{"paid": 16.333333333333332}, {"paid": 14.0}]
         assert res["myvalue"] == [
-            {(1, 'paid'): None, (0, 'paid'): 9, (2, 'paid'): 40}, 
-            {(0, 'paid'): 14}
+            {(1, "paid"): None, (0, "paid"): 9, (2, "paid"): 40},
+            {(0, "paid"): 14},
         ]
 
 
@@ -1496,7 +1517,11 @@ class TestVariableLengthRelationship:
         assert res["A"] == ["x", "y", "z"]
         assert res["B"] == ["y", "z", "x"]
         assert graph_type in ACCEPTED_GRAPH_TYPES
-        assert res["r"] == [[{0: {'bar': '1'}}], [{0: {'bar': '2'}}], [{0: {'bar': '3'}}]]
+        assert res["r"] == [
+            [{0: {"bar": "1"}}],
+            [{0: {"bar": "2"}}],
+            [{0: {"bar": "3"}}],
+        ]
 
         qry = """
         MATCH (A)-[r*2]->(B)
@@ -1509,9 +1534,9 @@ class TestVariableLengthRelationship:
         assert res["B"] == ["z", "x", "y"]
         assert graph_type in ACCEPTED_GRAPH_TYPES
         assert res["r"] == [
-            [{0: {'bar': '1'}}, {0: {'bar': '2'}}], 
-            [{0: {'bar': '2'}}, {0: {'bar': '3'}}], 
-            [{0: {'bar': '3'}}, {0: {'bar': '1'}}]
+            [{0: {"bar": "1"}}, {0: {"bar": "2"}}],
+            [{0: {"bar": "2"}}, {0: {"bar": "3"}}],
+            [{0: {"bar": "3"}}, {0: {"bar": "1"}}],
         ]
 
     @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
@@ -1535,13 +1560,15 @@ class TestVariableLengthRelationship:
         assert res["B"] == ["x", "y", "z", "y", "z", "x", "z", "x", "y"]
         assert graph_type in ACCEPTED_GRAPH_TYPES
         assert res["r"] == [
-            [None], [None], [None], 
-            [{0: {'bar': '1'}}], 
-            [{0: {'bar': '2'}}], 
-            [{0: {'bar': '3'}}], 
-            [{0: {'bar': '1'}}, {0: {'bar': '2'}}], 
-            [{0: {'bar': '2'}}, {0: {'bar': '3'}}], 
-            [{0: {'bar': '3'}}, {0: {'bar': '1'}}]
+            [None],
+            [None],
+            [None],
+            [{0: {"bar": "1"}}],
+            [{0: {"bar": "2"}}],
+            [{0: {"bar": "3"}}],
+            [{0: {"bar": "1"}}, {0: {"bar": "2"}}],
+            [{0: {"bar": "2"}}, {0: {"bar": "3"}}],
+            [{0: {"bar": "3"}}, {0: {"bar": "1"}}],
         ]
 
 
@@ -1649,15 +1676,15 @@ class TestType:
         assert res["B"] == ["x", "y", "z", "y", "z", "x", "z", "x", "y"]
         assert graph_type in ACCEPTED_GRAPH_TYPES
         assert res["r"] == [
-            [None], 
-            [None], 
-            [None], 
-            [{0: {'__labels__': {'Edge', 'XY'}}}], 
-            [{0: {'__labels__': {'Edge', 'YZ'}}}], 
-            [{0: {'__labels__': {'Edge', 'ZX'}}}], 
-            [{0: {'__labels__': {'Edge', 'XY'}}}, {0: {'__labels__': {'Edge', 'YZ'}}}], 
-            [{0: {'__labels__': {'Edge', 'YZ'}}}, {0: {'__labels__': {'Edge', 'ZX'}}}], 
-            [{0: {'__labels__': {'Edge', 'ZX'}}}, {0: {'__labels__': {'Edge', 'XY'}}}]
+            [None],
+            [None],
+            [None],
+            [{0: {"__labels__": {"Edge", "XY"}}}],
+            [{0: {"__labels__": {"Edge", "YZ"}}}],
+            [{0: {"__labels__": {"Edge", "ZX"}}}],
+            [{0: {"__labels__": {"Edge", "XY"}}}, {0: {"__labels__": {"Edge", "YZ"}}}],
+            [{0: {"__labels__": {"Edge", "YZ"}}}, {0: {"__labels__": {"Edge", "ZX"}}}],
+            [{0: {"__labels__": {"Edge", "ZX"}}}, {0: {"__labels__": {"Edge", "XY"}}}],
         ]
 
     @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
@@ -2065,7 +2092,10 @@ class TestPath:
         host.add_node("z", name="z")
 
         host.add_edge("x", "y", foo="bar")
-        host.add_edge("y", "z",)
+        host.add_edge(
+            "y",
+            "z",
+        )
 
         qry = """
         MATCH P = ()-[r*2]->()
@@ -2167,6 +2197,7 @@ class TestMatchWithOrOperatorInRelationships:
         assert res["n1.name"] == ["Bob", "Bob"]
         assert res["n2.name"] == ["Carol", "Derek"]
 
+
 class TestFunction:
     @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
     def test_id(self, graph_type):
@@ -2204,4 +2235,27 @@ class TestList:
         """
 
         res = GrandCypher(host).run(qry)
+        assert res["A"] == [1, 3]
+
+
+class TestReuse:
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_use_gc(self, graph_type):
+        host = graph_type()
+        host.add_node(1, name="Ford Prefect")
+        host.add_node(2, name="Arthur Dent")
+        host.add_node(3, name="John Smith")
+        host.add_edge(1, 2)
+        host.add_edge(2, 3)
+
+        qry = """
+        MATCH (A)
+        WHERE id(A) IN [1, 3]
+        RETURN A
+        """
+
+        gc = GrandCypher(host)
+        res = gc.run(qry)
+        assert res["A"] == [1, 3]
+        res = gc.run(qry)
         assert res["A"] == [1, 3]

--- a/grandcypher/test_queries.py
+++ b/grandcypher/test_queries.py
@@ -187,7 +187,6 @@ class TestSimpleAPI:
         res = GrandCypher(host).run(qry)
         assert len(res) == 1
         assert list(res.values())[0] == ["x", "x", "y"]
-        print(res)
 
     @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
     def test_single_edge_where(self, graph_type):
@@ -253,7 +252,6 @@ class TestSimpleAPI:
         AND BC.weight > 11
         RETURN AB
         """
-        print(GrandCypher(host).run(qry))
         assert len(GrandCypher(host).run(qry)["AB"]) == 1
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="grand-cypher",
-    version="0.13.0",
+    version="0.14.0",
     author="Jordan Matelsky",
     author_email="opensource@matelsky.com",
     description="Query Grand graphs using Cypher",


### PR DESCRIPTION
Hints are a feature of `grandiso` (first mentioned here in #63) that allow you to short-circuit the NP-hard vertex matching procedure (or prompt it with good starting data) to artificially set the matches of certain vertices in the motif. More details in `docs/Hints.md`.