### PR TITLE
Remove unused logging code

### DIFF
--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -11,18 +11,12 @@ from typing import Dict, Hashable, List, Callable, Optional, Tuple, Union
 from collections import OrderedDict
 import random
 import string
-import logging
 from functools import lru_cache
 import networkx as nx
 
 import grandiso
 
 from lark import Lark, Transformer, v_args, Token, Tree
-
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-)
-logger = logging.getLogger(__name__)
 
 
 _OPERATORS = {


### PR DESCRIPTION
Hello! I hope all is well.

I've recently noticed an issue in my dev environment where `INFO` logging statements were being logged when I hadn't set any logging configuration. I spent some debugging dependent libraries and it looks like unused logging statements here were the root cause.

Ironically, I had something like this a few years back with someone submitting a PR to fix it: https://github.com/neuml/txtai/pull/397 :smile: 