### PR TITLE
Quantexa arithmetic where

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -19,13 +19,13 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
-      - name: Cache virtual environment
+      - name: Cache uv
         uses: actions/cache@v3
         with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock', 'pyproject.toml') }}
           restore-keys: |
-            venv-${{ runner.os }}-
+            uv-${{ runner.os }}-
 
       - name: Set up uv venv and install dependencies
         run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,13 +26,13 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
-      - name: Cache virtual environment
+      - name: Cache uv
         uses: actions/cache@v3
         with:
-          path: .venv
-          key: venv-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('uv.lock', 'pyproject.toml') }}
           restore-keys: |
-            venv-${{ matrix.python-version }}-
+            uv-${{ runner.os }}-${{ matrix.python-version }}-
 
       - name: Set up uv venv and install dependencies
         run: |

--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -1112,6 +1112,10 @@ class GrandCypherExecutor:
 
         # Only after all other transformations, apply pagination
         results = self._apply_pagination(results, ignore_limit)
+        self._return_requests = [
+            r if isinstance(r, (EntityRef, IDRef)) else str(r)
+            for r in self._return_requests
+        ]
 
         # Only include keys that were asked for in `RETURN` in the final results
         results = {

--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -245,16 +245,26 @@ _ARITH_OPS = {
 
 
 class EntityRef(str):
-    """Reference to a node/edge attribute, e.g. A.value.
+    """Bare node/edge reference, e.g. A.
 
-    Remains a str subclass because the RETURN path uses these as dict keys
+    str subclass because the RETURN path uses these as dict keys
     and passes them through isinstance(item, str) checks.
     """
-    def __new__(cls, entity_name, attribute=None):
-        value = f"{entity_name}.{attribute}" if attribute else str(entity_name)
-        instance = super().__new__(cls, value)
+    def __new__(cls, entity_name):
+        instance = super().__new__(cls, str(entity_name))
         instance.entity_name = str(entity_name)
-        instance.attribute = str(attribute) if attribute else None
+        return instance
+
+
+class AttributeRef(str):
+    """Node/edge attribute reference, e.g. A.age.
+
+    str subclass for the same reason as EntityRef.
+    """
+    def __new__(cls, entity_name, attribute):
+        instance = super().__new__(cls, f"{entity_name}.{attribute}")
+        instance.entity_name = str(entity_name)
+        instance.attribute = str(attribute)
         return instance
 
 
@@ -294,19 +304,22 @@ def _resolve_operand(operand, match, host, return_edges):
         if operand.entity_name in match.node_mappings:
             return match.node_mappings[operand.entity_name]
         raise IndexError(f"Entity {operand.entity_name} not in match.")
-    if isinstance(operand, EntityRef):
+    if isinstance(operand, AttributeRef):
         entity_name = operand.entity_name
         attribute = operand.attribute
         if entity_name in match.node_mappings:
             host_node_id = match.node_mappings[entity_name]
-            if attribute:
-                return get_node_from_host(host, host_node_id, attribute)
-            return get_node_from_host(host, host_node_id)
+            return get_node_from_host(host, host_node_id, attribute)
         if entity_name in return_edges:
             edge_mapping = return_edges[entity_name]
             host_edges = match.mth.edge(*edge_mapping).edges
             return get_edge_from_host(host, host_edges, attribute)
         raise IndexError(f"Entity {operand} not in graph.")
+    if isinstance(operand, EntityRef):
+        raise TypeError(
+            f"Cannot use bare entity '{operand}' in a comparison. "
+            f"Use a property like '{operand}.attribute' or ID({operand})."
+        )
     return operand
 
 
@@ -775,8 +788,10 @@ _BOOL_ARI = {
 def _data_path_to_entity_name_attribute(data_path):
     if isinstance(data_path, IDRef):
         return data_path.entity_name, None
-    if isinstance(data_path, EntityRef):
+    if isinstance(data_path, AttributeRef):
         return data_path.entity_name, data_path.attribute
+    if isinstance(data_path, EntityRef):
+        return data_path.entity_name, None
     if isinstance(data_path, Token):
         data_path = data_path.value
     if "." in data_path:
@@ -825,12 +840,10 @@ def to_indexer_ast(condition: Condition, left = None, right = None, should_be=Tr
                                 left=condition._left,
                                 right=condition._right,
                                 should_be=condition._should_be)
-    if isinstance(left, ArithmeticExpression) or isinstance(right, ArithmeticExpression):
-        return IndexerUnsupportedOp(condition, left, right)
-    if isinstance(left, IDRef) or isinstance(right, IDRef):
-        return IndexerUnsupportedOp(condition, left, right)
     if (isinstance(condition, LambdaCompareCondition) and
-        condition._operator in WHERE_OPERATORS_TO_INDEXER_OPERATORS):
+        condition._operator in WHERE_OPERATORS_TO_INDEXER_OPERATORS and
+        isinstance(left, AttributeRef) and
+        isinstance(right, (int, float, str, bool, type(None)))):
         operator = condition._operator
         if should_be is True:
             operator = WHERE_OPERATORS_TO_INDEXER_OPERATORS[operator]
@@ -857,7 +870,7 @@ def motif_to_indexer_ast(motif: nx.DiGraph) -> IndexerConditionAST:
         for k, v in json_data.items():
             if k == "__labels__":
                 continue
-            k = cname + "." + k
+            k = AttributeRef(cname, k)
             if ast is None:
                 ast = IndexerCompare("==", k, v)
             else:
@@ -1113,7 +1126,7 @@ class GrandCypherExecutor:
         # Only after all other transformations, apply pagination
         results = self._apply_pagination(results, ignore_limit)
         self._return_requests = [
-            r if isinstance(r, (EntityRef, IDRef)) else str(r)
+            r if isinstance(r, (EntityRef, AttributeRef, IDRef)) else str(r)
             for r in self._return_requests
         ]
 
@@ -1635,7 +1648,7 @@ class GrandCypherTransformer(Transformer):
 
     def entity_id(self, entity_id):
         if len(entity_id) == 2:
-            return EntityRef(entity_id[0], entity_id[1])
+            return AttributeRef(entity_id[0], entity_id[1])
         return EntityRef(entity_id[0].value)
 
     def edge_match(self, edge_tokens):

--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -49,16 +49,27 @@ compound_condition  : condition
                     | "(" compound_condition boolean_arithmetic compound_condition ")"
                     | compound_condition boolean_arithmetic compound_condition
 
-condition           : (entity_id | scalar_function) op entity_id_or_value
-                    | (entity_id | scalar_function) op_list value_list
+condition           : arith_expr op arith_expr
+                    | (entity_id | scalar_function) op_list value_list  // IN: no arithmetic on LHS by design
                     | sub_query
                     | "not"i condition -> condition_not
 
-?entity_id_or_value : entity_id
+?arith_expr         : arith_term
+                    | arith_expr "+" arith_term -> arith_add
+                    | arith_expr "-" arith_term -> arith_sub
+
+?arith_term         : arith_atom
+                    | arith_term "*" arith_atom -> arith_mul
+                    | arith_term "/" arith_atom -> arith_div
+                    | arith_term "%" arith_atom -> arith_mod
+
+?arith_atom         : entity_id
+                    | scalar_function
                     | value
                     | NULL -> null
                     | TRUE -> true
                     | FALSE -> false
+                    | "(" arith_expr ")"
 
 op                  : "==" -> op_eq
                     | "=" -> op_eq
@@ -221,6 +232,82 @@ class SUBOP_EXIST(SUBOP):
 _SUB_OPERATORS = {
     "EXISTS": SUBOP_EXIST
 }
+
+
+_ARITH_OPS = {
+    "+": lambda a, b: a + b,
+    "-": lambda a, b: a - b,
+    "*": lambda a, b: a * b,
+    # Integer division to match Neo4j/Cypher semantics
+    "/": lambda a, b: a // b if isinstance(a, int) and isinstance(b, int) else a / b,
+    "%": lambda a, b: a % b,
+}
+
+
+class EntityRef(str):
+    """Reference to a node/edge attribute, e.g. A.value.
+
+    Remains a str subclass because the RETURN path uses these as dict keys
+    and passes them through isinstance(item, str) checks.
+    """
+    def __new__(cls, entity_name, attribute=None):
+        value = f"{entity_name}.{attribute}" if attribute else str(entity_name)
+        instance = super().__new__(cls, value)
+        instance.entity_name = str(entity_name)
+        instance.attribute = str(attribute) if attribute else None
+        return instance
+
+
+class IDRef(str):
+    """Reference to ID(A) in WHERE clauses.
+
+    str subclass for the same reason as EntityRef.
+    """
+    def __new__(cls, entity_name):
+        instance = super().__new__(cls, f"ID({entity_name})")
+        instance.entity_name = str(entity_name)
+        return instance
+
+
+class ArithmeticExpression:
+    def __init__(self, left, op: str, right):
+        self.left = left
+        self.op = op
+        self.right = right
+
+    def resolve(self, match, host, return_edges):
+        left_val = _resolve_operand(self.left, match, host, return_edges)
+        right_val = _resolve_operand(self.right, match, host, return_edges)
+        try:
+            return _ARITH_OPS[self.op](left_val, right_val)
+        except (TypeError, ZeroDivisionError, OverflowError):
+            return None
+
+    def __str__(self):
+        return f"({self.left} {self.op} {self.right})"
+
+
+def _resolve_operand(operand, match, host, return_edges):
+    if isinstance(operand, ArithmeticExpression):
+        return operand.resolve(match, host, return_edges)
+    if isinstance(operand, IDRef):
+        if operand.entity_name in match.node_mappings:
+            return match.node_mappings[operand.entity_name]
+        raise IndexError(f"Entity {operand.entity_name} not in match.")
+    if isinstance(operand, EntityRef):
+        entity_name = operand.entity_name
+        attribute = operand.attribute
+        if entity_name in match.node_mappings:
+            host_node_id = match.node_mappings[entity_name]
+            if attribute:
+                return get_node_from_host(host, host_node_id, attribute)
+            return get_node_from_host(host, host_node_id)
+        if entity_name in return_edges:
+            edge_mapping = return_edges[entity_name]
+            host_edges = match.mth.edge(*edge_mapping).edges
+            return get_edge_from_host(host, host_edges, attribute)
+        raise IndexError(f"Entity {operand} not in graph.")
+    return operand
 
 
 @lru_cache()
@@ -626,52 +713,28 @@ class LambdaCompareCondition(CompareCondition):
 
 class CompoundCondition(Condition):
     """compound condition"""
-    def __init__(self, should_be: bool, entity_id: str, operator, value):
+    def __init__(self, should_be: bool, left, operator, right):
         self._should_be = should_be
-        self._entity_id = entity_id
+        self._left = left
         self._operator = operator
-        self._value = value
+        self._right = right
 
     def __str__(self):
-        return f"compound of {self._operator} for key {self._entity_id}: value {self._value}"
+        return f"compound of {self._operator} for {self._left}: {self._right}"
 
-    # def __call__(self, match: dict, host: nx.DiGraph, return_edges: list, edge_hop_map = None, edge_hop_key = None) -> bool:
     def __call__(self, match: Match, host: nx.DiGraph, return_edges: list) -> bool:
-        # Check if this is an ID function call
-        if self._entity_id.startswith("ID(") and self._entity_id.endswith(")"):
-            # Extract the entity name from ID(entity_name)
-            actual_entity_name = self._entity_id[3:-1]  # Remove "ID(" and ")"
-            if actual_entity_name in match.node_mappings:
-                # Return the node ID directly
-                node_id = match.node_mappings[actual_entity_name]
-                try:
-                    val = self._operator(node_id, self._value)
-                except:
-                    val = False
-                operator_results = [val]
-            else:
-                raise IndexError(f"Entity {actual_entity_name} not in match.")
+        if isinstance(self._operator, SUBOP):
+            val = self._operator(match.node_mappings, self._right)
         else:
-            host_entity_id = self._entity_id.split(".")
-            if isinstance(self._operator, SUBOP):
-                # SUBOP operator doesn't need a entity id.
-                val = self._operator(match.node_mappings, self._value)
-            elif host_entity_id[0] in match.node_mappings:
-                # Regular entity attribute access
-                host_entity_id[0] = match.node_mappings[host_entity_id[0]]
-                val = self._operator(get_node_from_host(host, host_entity_id[0], host_entity_id[1]), self._value)
-            elif host_entity_id[0] in return_edges:
-                # looking for edge...
-                entity_name, entity_attribute = _data_path_to_entity_name_attribute(self._entity_id)
-                edge_mapping = return_edges[entity_name]
-
-                host_edges = match.mth.edge(*edge_mapping).edges
-                val = self._operator(get_edge_from_host(host, host_edges, entity_attribute), self._value)
-            else:
-                raise IndexError(f"Entity {host_entity_id} not in graph.")
+            left = _resolve_operand(self._left, match, host, return_edges)
+            right = _resolve_operand(self._right, match, host, return_edges)
+            try:
+                val = self._operator(left, right)
+            except (TypeError, AttributeError):
+                val = False
         operator_results = [val]
         if val is None:
-            val is False
+            val = False
         if val != self._should_be:
             return False, operator_results
         return True, operator_results
@@ -710,6 +773,10 @@ _BOOL_ARI = {
 
 
 def _data_path_to_entity_name_attribute(data_path):
+    if isinstance(data_path, IDRef):
+        return data_path.entity_name, None
+    if isinstance(data_path, EntityRef):
+        return data_path.entity_name, data_path.attribute
     if isinstance(data_path, Token):
         data_path = data_path.value
     if "." in data_path:
@@ -751,35 +818,36 @@ def create_node_indexer(target_graph: nx.DiGraph) -> ArrayAttributeIndexer:
     return indexer
 
 
-def to_indexer_ast(condition: Condition, entity_id = None, value = None, should_be=True) -> IndexerConditionAST:
+def to_indexer_ast(condition: Condition, left = None, right = None, should_be=True) -> IndexerConditionAST:
     """convert where condition to IndexerConditionAST which can be run with IndexerConditionRunner"""
-    # for condition in condition:
     if isinstance(condition, CompoundCondition):
         return to_indexer_ast(condition=condition._operator,
-                                entity_id=condition._entity_id,
-                                value=condition._value,
+                                left=condition._left,
+                                right=condition._right,
                                 should_be=condition._should_be)
+    if isinstance(left, ArithmeticExpression) or isinstance(right, ArithmeticExpression):
+        return IndexerUnsupportedOp(condition, left, right)
     if (isinstance(condition, LambdaCompareCondition) and
         condition._operator in WHERE_OPERATORS_TO_INDEXER_OPERATORS):
-        if entity_id.startswith("ID()"):
-            entity_id = entity_id[3:-1]
+        if isinstance(left, IDRef):
+            left = left.entity_name
         operator = condition._operator
         if should_be is True:
             operator = WHERE_OPERATORS_TO_INDEXER_OPERATORS[operator]
         else:
             operator = NOT_WHERE_OPERATORS_TO_INDEXER_OPERATORS[operator]
-        return IndexerCompare(operator, entity_id, value)
+        return IndexerCompare(operator, left, right)
     if isinstance(condition, OR):
         return IndexerOr(
-            to_indexer_ast(condition._condition_a, entity_id, value),
-            to_indexer_ast(condition._condition_b, entity_id, value),
+            to_indexer_ast(condition._condition_a, left, right),
+            to_indexer_ast(condition._condition_b, left, right),
         )
     if isinstance(condition, AND):
         return IndexerAnd(
-            to_indexer_ast(condition._condition_a, entity_id, value),
-            to_indexer_ast(condition._condition_b, entity_id, value),
+            to_indexer_ast(condition._condition_a, left, right),
+            to_indexer_ast(condition._condition_b, left, right),
         )
-    return IndexerUnsupportedOp(condition, entity_id, value)
+    return IndexerUnsupportedOp(condition, left, right)
 
 
 def motif_to_indexer_ast(motif: nx.DiGraph) -> IndexerConditionAST:
@@ -866,29 +934,23 @@ class GrandCypherExecutor:
 
         # handling RETURN ID(A)
         for data_path in data_paths:
-            entity_name, _ = _data_path_to_entity_name_attribute(data_path)
-            # Special handling for ID function
-            if entity_name.upper().startswith("ID(") and entity_name.endswith(")"):
-                # Extract the original entity name
-                original_entity = entity_name[3:-1]
+            if isinstance(data_path, IDRef):
+                original_entity = data_path.entity_name
                 if original_entity in motif_nodes:
-                    # Return the node ID directly instead of the node attributes
                     ret = [match.mth.node(original_entity) for match in true_matches]
                     result[data_path] = ret[offset_limit]
-                    result[original_entity] = ret[
-                        offset_limit
-                    ]  # Also store under original entity name
-                    processed_paths.add(data_path)  # Mark as processed
-                    processed_paths.add(
-                        original_entity
-                    )  # Mark original also as processed
+                    result[original_entity] = ret[offset_limit]
+                    processed_paths.add(data_path)
+                    processed_paths.add(original_entity)
                     continue
-            if (
-                entity_name not in motif_nodes
-                and entity_name not in self._return_edges
-                and entity_name not in self._paths
-            ):
-                raise NotImplementedError(f"Unknown entity name: {data_path}")
+            else:
+                entity_name, _ = _data_path_to_entity_name_attribute(data_path)
+                if (
+                    entity_name not in motif_nodes
+                    and entity_name not in self._return_edges
+                    and entity_name not in self._paths
+                ):
+                    raise NotImplementedError(f"Unknown entity name: {data_path}")
 
         for data_path in data_paths:
             if data_path in processed_paths:  # Skip already processed paths
@@ -1050,7 +1112,6 @@ class GrandCypherExecutor:
 
         # Only after all other transformations, apply pagination
         results = self._apply_pagination(results, ignore_limit)
-        self._return_requests = list(map(str, self._return_requests))
 
         # Only include keys that were asked for in `RETURN` in the final results
         results = {
@@ -1570,8 +1631,8 @@ class GrandCypherTransformer(Transformer):
 
     def entity_id(self, entity_id):
         if len(entity_id) == 2:
-            return ".".join(entity_id)
-        return entity_id.value
+            return EntityRef(entity_id[0], entity_id[1])
+        return EntityRef(entity_id[0].value)
 
     def edge_match(self, edge_tokens):
         def flatten_tokens(edge_tokens):
@@ -1735,13 +1796,28 @@ class GrandCypherTransformer(Transformer):
         # This ensures tests like test_id can still access res["A"]
         # self._return_requests.append(entity_name)
         # Return a special identifier that will be processed in _lookup method
-        return f"ID({entity_name})"
+        return IDRef(entity_name)
 
     def value_list(self, items):
         return list(items)
 
     def op(self, operator):
         return operator
+
+    def arith_add(self, items):
+        return ArithmeticExpression(items[0], "+", items[1])
+
+    def arith_sub(self, items):
+        return ArithmeticExpression(items[0], "-", items[1])
+
+    def arith_mul(self, items):
+        return ArithmeticExpression(items[0], "*", items[1])
+
+    def arith_div(self, items):
+        return ArithmeticExpression(items[0], "/", items[1])
+
+    def arith_mod(self, items):
+        return ArithmeticExpression(items[0], "%", items[1])
 
     def op_eq(self, _):
         return _OPERATORS["=="]

--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -239,8 +239,8 @@ _ARITH_OPS = {
     "+": lambda a, b: a + b,
     "-": lambda a, b: a - b,
     "*": lambda a, b: a * b,
-    # Integer division to match Neo4j/Cypher semantics
-    "/": lambda a, b: a // b if isinstance(a, int) and isinstance(b, int) else a / b,
+    # Truncate-toward-zero integer division to match Neo4j/Cypher semantics
+    "/": lambda a, b: int(a / b) if isinstance(a, int) and isinstance(b, int) else a / b,
     "%": lambda a, b: a % b,
 }
 

--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -26,6 +26,7 @@ from .indexer import (
     Compare as IndexerCompare, OR as IndexerOr,
     AND as IndexerAnd, ArrayAttributeIndexer, IndexerConditionAST,
     UnsupportedOp as IndexerUnsupportedOp, IndexerConditionRunner)
+from .types import EntityRef, AttributeRef, IDRef
 
 
 _GrandCypherGrammar = Lark(
@@ -242,41 +243,6 @@ _ARITH_OPS = {
     "/": lambda a, b: a // b if isinstance(a, int) and isinstance(b, int) else a / b,
     "%": lambda a, b: a % b,
 }
-
-
-class EntityRef(str):
-    """Bare node/edge reference, e.g. A.
-
-    str subclass because the RETURN path uses these as dict keys
-    and passes them through isinstance(item, str) checks.
-    """
-    def __new__(cls, entity_name):
-        instance = super().__new__(cls, str(entity_name))
-        instance.entity_name = str(entity_name)
-        return instance
-
-
-class AttributeRef(str):
-    """Node/edge attribute reference, e.g. A.age.
-
-    str subclass for the same reason as EntityRef.
-    """
-    def __new__(cls, entity_name, attribute):
-        instance = super().__new__(cls, f"{entity_name}.{attribute}")
-        instance.entity_name = str(entity_name)
-        instance.attribute = str(attribute)
-        return instance
-
-
-class IDRef(str):
-    """Reference to ID(A) in WHERE clauses.
-
-    str subclass for the same reason as EntityRef.
-    """
-    def __new__(cls, entity_name):
-        instance = super().__new__(cls, f"ID({entity_name})")
-        instance.entity_name = str(entity_name)
-        return instance
 
 
 class ArithmeticExpression:
@@ -799,7 +765,6 @@ def _data_path_to_entity_name_attribute(data_path):
     else:
         entity_name = data_path
         entity_attribute = None
-
     return entity_name, entity_attribute
 
 
@@ -850,6 +815,12 @@ def to_indexer_ast(condition: Condition, left = None, right = None, should_be=Tr
         else:
             operator = NOT_WHERE_OPERATORS_TO_INDEXER_OPERATORS[operator]
         return IndexerCompare(operator, left, right)
+    if (isinstance(condition, LambdaCompareCondition) and
+        condition._operator == "==" and
+        should_be is True and
+        isinstance(left, IDRef) and
+        isinstance(right, (int, float, str, bool))):
+        return IndexerCompare("==", left, right)
     if isinstance(condition, OR):
         return IndexerOr(
             to_indexer_ast(condition._condition_a, left, right),

--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -827,10 +827,10 @@ def to_indexer_ast(condition: Condition, left = None, right = None, should_be=Tr
                                 should_be=condition._should_be)
     if isinstance(left, ArithmeticExpression) or isinstance(right, ArithmeticExpression):
         return IndexerUnsupportedOp(condition, left, right)
+    if isinstance(left, IDRef) or isinstance(right, IDRef):
+        return IndexerUnsupportedOp(condition, left, right)
     if (isinstance(condition, LambdaCompareCondition) and
         condition._operator in WHERE_OPERATORS_TO_INDEXER_OPERATORS):
-        if isinstance(left, IDRef):
-            left = left.entity_name
         operator = condition._operator
         if should_be is True:
             operator = WHERE_OPERATORS_TO_INDEXER_OPERATORS[operator]

--- a/grandcypher/indexer.py
+++ b/grandcypher/indexer.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Hashable, TypeVar, Union
 from bisect import bisect_left, bisect_right
 from cachetools import LRUCache
 
-from .types import IDRef
+from .types import AttributeRef, IDRef
 
 
 T = TypeVar("T")
@@ -241,16 +241,21 @@ class OR:
 
 class Compare:
     def __init__(self, op, key, value):
+        if not isinstance(key, (AttributeRef, IDRef)):
+            raise TypeError(
+                f"Compare received unexpected key type {type(key).__name__}, "
+                f"expected AttributeRef or IDRef"
+            )
+        if isinstance(key, IDRef) and op != "==":
+            raise ValueError(
+                f"ID() comparisons only support '==' in the indexer, got '{op}'"
+            )
         self._op = op
         self._key = key
         self._value = value
 
     def __call__(self, indexer: ArrayAttributeIndexer):
         if isinstance(self._key, IDRef):
-            if self._op != "==":
-                raise ValueError(
-                    f"ID() comparisons only support '==' in the indexer, got '{self._op}'"
-                )
             return {self._key.entity_name: {self._value}}
         querier = indexer.get_index_querier(self._key.attribute)
         comparator = querier.get_comparator(self._op)

--- a/grandcypher/indexer.py
+++ b/grandcypher/indexer.py
@@ -7,6 +7,8 @@ from typing import Any, Callable, Hashable, TypeVar, Union
 from bisect import bisect_left, bisect_right
 from cachetools import LRUCache
 
+from .types import IDRef
+
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -244,6 +246,12 @@ class Compare:
         self._value = value
 
     def __call__(self, indexer: ArrayAttributeIndexer):
+        if isinstance(self._key, IDRef):
+            if self._op != "==":
+                raise ValueError(
+                    f"ID() comparisons only support '==' in the indexer, got '{self._op}'"
+                )
+            return {self._key.entity_name: {self._value}}
         querier = indexer.get_index_querier(self._key.attribute)
         comparator = querier.get_comparator(self._op)
         return {self._key.entity_name: comparator(self._value)}

--- a/grandcypher/indexer.py
+++ b/grandcypher/indexer.py
@@ -244,18 +244,9 @@ class Compare:
         self._value = value
 
     def __call__(self, indexer: ArrayAttributeIndexer):
-        name_attr = self._key.split(".")
-        if len(name_attr) == 1:
-            try:
-                iter(self._value)
-                value = self._value
-            except TypeError:
-                value = [self._value]
-            return {self._key: set(value)}
-        name, attr= name_attr
-        querier = indexer.get_index_querier(attr)
+        querier = indexer.get_index_querier(self._key.attribute)
         comparator = querier.get_comparator(self._op)
-        return {name: comparator(self._value)}
+        return {self._key.entity_name: comparator(self._value)}
 
 
 class UnsupportedOp:

--- a/grandcypher/test_indexer.py
+++ b/grandcypher/test_indexer.py
@@ -1,4 +1,5 @@
 import pytest
+from . import AttributeRef
 from .indexer import (
     SKIP, AND, OR, Compare, IndexerConditionRunner, NoIndexQuerier, ArrayAttributeIndexer,
     IncrementIndexQuerier)
@@ -40,7 +41,7 @@ def test_compare_returns_correct_mapping():
         }
     })
 
-    c = Compare(">", "A.age", 20)
+    c = Compare(">", AttributeRef("A", "age"), 20)
     result = c(indexer)
 
     assert result == {"A": {10, 11}}
@@ -52,8 +53,8 @@ def test_and_basic_intersection():
         "height": {"<": {2,3,4}},
     })
 
-    left  = Compare(">", "A.age", 20)       # {"A": {1,2,3}}
-    right = Compare("<", "A.height", 100)   # {"A": {2,3,4}}
+    left  = Compare(">", AttributeRef("A", "age"), 20)       # {"A": {1,2,3}}
+    right = Compare("<", AttributeRef("A", "height"), 100)   # {"A": {2,3,4}}
 
     node = AND(left, right)
     result = node(indexer)
@@ -68,7 +69,7 @@ def test_and_left_is_skip():
     })
 
     left = SKIP()
-    right = Compare(">", "A.age", 20)
+    right = Compare(">", AttributeRef("A", "age"), 20)
     node = AND(left, right)
 
     assert node(indexer) == {"A": {1,2,3}}
@@ -80,7 +81,7 @@ def test_and_right_is_skip():
         "age": {">": {1}},
     })
 
-    left = Compare(">", "A.age", 20)
+    left = Compare(">", AttributeRef("A", "age"), 20)
     right = SKIP()
     node = AND(left, right)
 
@@ -94,8 +95,8 @@ def test_and_two_variables():
         "score": {"<": {5,6}},
     })
 
-    a = Compare(">", "A.age", 20)        # {"A": {1,2}}
-    b = Compare("<", "B.score", 200)     # {"B": {5,6}}
+    a = Compare(">", AttributeRef("A", "age"), 20)        # {"A": {1,2}}
+    b = Compare("<", AttributeRef("B", "score"), 200)     # {"B": {5,6}}
 
     node = AND(a, b)
     result = node(indexer)
@@ -112,8 +113,8 @@ def test_or_union():
         "age": {">": {1,2}, "<": {2,3}},
     })
 
-    a = Compare(">", "A.age", 20)      # {"A": {1,2}}
-    b = Compare("<", "A.age", 100)     # {"A": {2,3}}
+    a = Compare(">", AttributeRef("A", "age"), 20)      # {"A": {1,2}}
+    b = Compare("<", AttributeRef("A", "age"), 100)     # {"A": {2,3}}
 
     node = OR(a, b)
     result = node(indexer)
@@ -128,8 +129,8 @@ def test_or_disjoint_keys():
         "score": {"<": {9}},
     })
 
-    a = Compare(">", "A.age", 0)         # {"A": {1}}
-    b = Compare("<", "B.score", 100)     # {"B": {9}}
+    a = Compare(">", AttributeRef("A", "age"), 0)         # {"A": {1}}
+    b = Compare("<", AttributeRef("B", "score"), 100)     # {"B": {9}}
 
     result = OR(a, b)(indexer)
 
@@ -145,7 +146,7 @@ def test_runner_executes_ast():
         "age": {">": {7}},
     })
 
-    ast = Compare(">", "A.age", 10)
+    ast = Compare(">", AttributeRef("A", "age"), 10)
     runner = IndexerConditionRunner(indexer)
 
     assert runner.find(ast) == {"A": {7}}
@@ -165,10 +166,10 @@ def test_nested_ast():
 
     ast = AND(
         OR(
-            Compare(">", "A.age", 10),   # {1,2,3}
-            Compare("<", "A.age", 100),  # {3,4}
+            Compare(">", AttributeRef("A", "age"), 10),   # {1,2,3}
+            Compare("<", AttributeRef("A", "age"), 100),  # {3,4}
         ),
-        Compare("==", "B.score", 10)     # {10}
+        Compare("==", AttributeRef("B", "score"), 10)     # {10}
     )
 
     result = ast(indexer)
@@ -187,7 +188,7 @@ def test_or_with_skip():
 
     ast = OR(
         SKIP(),                         # {}
-        Compare(">", "A.age", 10)       # {"A": {5}}
+        Compare(">", AttributeRef("A", "age"), 10)       # {"A": {5}}
     )
 
     result = ast(indexer)

--- a/grandcypher/test_indexer_plumbing.py
+++ b/grandcypher/test_indexer_plumbing.py
@@ -1,0 +1,95 @@
+"""Plumbing tests that verify the indexer produces correct hints for grandiso.
+
+These tests mock grandiso.find_motifs_iter to inspect the hints kwarg,
+ensuring the indexer narrows candidates correctly (or doesn't when it can't).
+"""
+
+from unittest.mock import patch
+
+import grandiso
+import networkx as nx
+
+from . import GrandCypher
+
+
+def _get_hints(host, qry):
+    """Run a query and return the hints passed to grandiso."""
+    with patch(
+        "grandcypher.grandiso.find_motifs_iter",
+        wraps=grandiso.find_motifs_iter,
+    ) as mock:
+        GrandCypher(host).run(qry)
+        return mock.call_args.kwargs["hints"]
+
+
+def _hint_values(hints, entity):
+    """Extract the set of node IDs hinted for an entity."""
+    return {h[entity] for h in hints if entity in h}
+
+
+class TestIndexerProducesHints:
+
+    def test_equality_filters_to_matching_node(self):
+        host = nx.DiGraph()
+        host.add_node(1, name="Alice")
+        host.add_node(2, name="Bob")
+        host.add_node(3, name="Charlie")
+        host.add_edge(1, 2)
+        host.add_edge(2, 3)
+
+        hints = _get_hints(host, 'MATCH (A) WHERE A.name == "Bob" RETURN A')
+        assert _hint_values(hints, "A") == {2}
+
+    def test_inequality_filters_to_matching_nodes(self):
+        host = nx.DiGraph()
+        host.add_node(1, age=10)
+        host.add_node(2, age=30)
+        host.add_node(3, age=50)
+        host.add_edge(1, 2)
+        host.add_edge(2, 3)
+
+        hints = _get_hints(host, "MATCH (A) WHERE A.age > 20 RETURN A")
+        assert _hint_values(hints, "A") == {2, 3}
+
+    def test_hint_only_constrains_referenced_entity(self):
+        host = nx.DiGraph()
+        host.add_node(1, age=10)
+        host.add_node(2, age=30)
+        host.add_node(3, age=50)
+        host.add_edge(1, 2)
+        host.add_edge(2, 3)
+
+        hints = _get_hints(host, "MATCH (A)-[]->(B) WHERE A.age > 20 RETURN A, B")
+        assert _hint_values(hints, "A") == {2, 3}
+        assert all("B" not in h for h in hints)
+
+
+class TestIndexerFallsBackToFullScan:
+
+    def test_id_ref_produces_no_hints(self):
+        host = nx.DiGraph()
+        host.add_node(1, name="Alice")
+        host.add_node(2, name="Bob")
+        host.add_edge(1, 2)
+
+        hints = _get_hints(host, "MATCH (A) WHERE ID(A) > 1 RETURN A")
+        assert hints == []
+
+    def test_arithmetic_produces_no_hints(self):
+        host = nx.DiGraph()
+        host.add_node(1, age=10)
+        host.add_node(2, age=30)
+        host.add_edge(1, 2)
+
+        hints = _get_hints(host, "MATCH (A) WHERE A.age + 10 > 30 RETURN A")
+        assert hints == []
+
+    def test_edge_attribute_produces_no_hints(self):
+        host = nx.DiGraph()
+        host.add_node(1, name="Alice")
+        host.add_node(2, name="Bob")
+        host.add_edge(1, 2, weight=10)
+        host.add_edge(2, 1, weight=50)
+
+        hints = _get_hints(host, "MATCH (A)-[E]->(B) WHERE E.weight > 20 RETURN A, B")
+        assert hints == []

--- a/grandcypher/test_indexer_plumbing.py
+++ b/grandcypher/test_indexer_plumbing.py
@@ -66,7 +66,18 @@ class TestIndexerProducesHints:
 
 class TestIndexerFallsBackToFullScan:
 
-    def test_id_ref_produces_no_hints(self):
+    def test_id_equality_produces_hints(self):
+        host = nx.DiGraph()
+        host.add_node(1, name="Alice")
+        host.add_node(2, name="Bob")
+        host.add_node(3, name="Charlie")
+        host.add_edge(1, 2)
+        host.add_edge(2, 3)
+
+        hints = _get_hints(host, "MATCH (A) WHERE ID(A) == 2 RETURN A")
+        assert _hint_values(hints, "A") == {2}
+
+    def test_id_inequality_produces_no_hints(self):
         host = nx.DiGraph()
         host.add_node(1, name="Alice")
         host.add_node(2, name="Bob")

--- a/grandcypher/test_parser.py
+++ b/grandcypher/test_parser.py
@@ -1,3 +1,5 @@
+from lark import Token, Tree
+
 from . import _GrandCypherGrammar
 
 
@@ -21,3 +23,154 @@ class TestParsing:
         """
         )
         assert len(tree.children[0].children) == 3
+
+
+class TestArithmeticParsing:
+    def test_parse_subtraction(self):
+        tree = _GrandCypherGrammar.parse(
+            """
+        MATCH (A)-[B]->(C)
+        WHERE A.x - A.y < 50
+        RETURN A
+        """
+        )
+        where = tree.children[0].children[1]
+        condition = where.children[0].children[0]
+        assert condition.children[0].data == "arith_sub"
+        assert condition.children[1].data == "op_lt"
+        assert condition.children[2] == Token("NUMBER", "50")
+
+    def test_parse_addition(self):
+        tree = _GrandCypherGrammar.parse(
+            """
+        MATCH (A)
+        WHERE A.x + 10 > 20
+        RETURN A
+        """
+        )
+        where = tree.children[0].children[1]
+        condition = where.children[0].children[0]
+        assert condition.children[0].data == "arith_add"
+        assert condition.children[1].data == "op_gt"
+        assert condition.children[2] == Token("NUMBER", "20")
+
+    def test_parse_multiplication(self):
+        tree = _GrandCypherGrammar.parse(
+            """
+        MATCH (A)
+        WHERE A.price * A.qty > 100
+        RETURN A
+        """
+        )
+        where = tree.children[0].children[1]
+        condition = where.children[0].children[0]
+        assert condition.children[0].data == "arith_mul"
+        assert condition.children[1].data == "op_gt"
+        assert condition.children[2] == Token("NUMBER", "100")
+
+    def test_parse_division(self):
+        tree = _GrandCypherGrammar.parse(
+            """
+        MATCH (A)
+        WHERE A.total / A.count >= 5
+        RETURN A
+        """
+        )
+        where = tree.children[0].children[1]
+        condition = where.children[0].children[0]
+        assert condition.children[0].data == "arith_div"
+        assert condition.children[1].data == "op_gte"
+        assert condition.children[2] == Token("NUMBER", "5")
+
+    def test_parse_modulo(self):
+        tree = _GrandCypherGrammar.parse(
+            """
+        MATCH (A)
+        WHERE A.value % 2 == 0
+        RETURN A
+        """
+        )
+        where = tree.children[0].children[1]
+        condition = where.children[0].children[0]
+        assert condition.children[0].data == "arith_mod"
+        assert condition.children[1].data == "op_eq"
+        assert condition.children[2] == Token("NUMBER", "0")
+
+    def test_parse_parenthesized(self):
+        tree = _GrandCypherGrammar.parse(
+            """
+        MATCH (A)
+        WHERE (A.x + A.y) * 2 < 100
+        RETURN A
+        """
+        )
+        where = tree.children[0].children[1]
+        condition = where.children[0].children[0]
+        lhs = condition.children[0]
+        assert lhs.data == "arith_mul"
+        assert lhs.children[0].data == "arith_add"
+        assert condition.children[1].data == "op_lt"
+        assert condition.children[2] == Token("NUMBER", "100")
+
+    def test_parse_arithmetic_preserves_precedence(self):
+        tree = _GrandCypherGrammar.parse(
+            """
+        MATCH (A)
+        WHERE A.x + A.y * 2 < 100
+        RETURN A
+        """
+        )
+        where = tree.children[0].children[1]
+        compound = where.children[0]
+        condition = compound.children[0]
+        lhs = condition.children[0]
+        assert isinstance(lhs, Tree)
+        assert lhs.data == "arith_add"
+        assert lhs.children[1].data == "arith_mul"
+
+    def test_parse_arithmetic_both_sides(self):
+        tree = _GrandCypherGrammar.parse(
+            """
+        MATCH (A)
+        WHERE A.x - 1 > A.y + 1
+        RETURN A
+        """
+        )
+        where = tree.children[0].children[1]
+        condition = where.children[0].children[0]
+        assert condition.children[0].data == "arith_sub"
+        assert condition.children[1].data == "op_gt"
+        assert condition.children[2].data == "arith_add"
+
+    def test_parse_chained_arithmetic(self):
+        tree = _GrandCypherGrammar.parse(
+            """
+        MATCH (A)
+        WHERE A.x + A.y - A.z > 0
+        RETURN A
+        """
+        )
+        where = tree.children[0].children[1]
+        compound = where.children[0]
+        condition = compound.children[0]
+        lhs = condition.children[0]
+        assert isinstance(lhs, Tree)
+        assert lhs.data == "arith_sub"
+        assert lhs.children[0].data == "arith_add"
+
+    def test_parse_nested_parenthesized(self):
+        tree = _GrandCypherGrammar.parse(
+            """
+        MATCH (A)
+        WHERE ((A.x + 1) * 2) - 3 > 10
+        RETURN A
+        """
+        )
+        where = tree.children[0].children[1]
+        condition = where.children[0].children[0]
+        lhs = condition.children[0]
+        assert lhs.data == "arith_sub"
+        assert lhs.children[0].data == "arith_mul"
+        assert lhs.children[0].children[0].data == "arith_add"
+        assert condition.children[1].data == "op_gt"
+        assert condition.children[2] == Token("NUMBER", "10")

--- a/grandcypher/test_queries.py
+++ b/grandcypher/test_queries.py
@@ -2731,3 +2731,350 @@ def test_equijoin2():
     assert GrandCypher(G).run(qry) == {
         "ID(n)": ["x"]
     }
+
+
+class TestArithmeticExpressions:
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_subtraction_in_where(self, graph_type):
+        host = graph_type()
+        host.add_node("a", amount1=100, amount2=60)
+        host.add_node("b", amount1=100, amount2=80)
+        host.add_node("c", amount1=200, amount2=10)
+        host.add_edge("a", "b")
+        host.add_edge("b", "c")
+
+        qry = """
+        MATCH (A)
+        WHERE A.amount1 - A.amount2 < 50
+        RETURN A.amount1, A.amount2
+        """
+        res = GrandCypher(host).run(qry)
+        assert len(res["A.amount1"]) == 2
+        assert set(zip(res["A.amount1"], res["A.amount2"])) == {(100, 60), (100, 80)}
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_multiplication_in_where(self, graph_type):
+        host = graph_type()
+        host.add_node("a", price=10, quantity=5)
+        host.add_node("b", price=20, quantity=100)
+        host.add_edge("a", "b")
+
+        qry = """
+        MATCH (A)
+        WHERE A.price * A.quantity > 100
+        RETURN A.price
+        """
+        res = GrandCypher(host).run(qry)
+        assert res["A.price"] == [20]
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_integer_division_in_where(self, graph_type):
+        host = graph_type()
+        host.add_node("a", total=7, count=2)
+        host.add_node("b", total=10, count=3)
+        host.add_edge("a", "b")
+
+        qry = """
+        MATCH (A)
+        WHERE A.total / A.count == 3
+        RETURN A.total
+        """
+        res = GrandCypher(host).run(qry)
+        assert set(res["A.total"]) == {7, 10}
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_float_division_in_where(self, graph_type):
+        host = graph_type()
+        host.add_node("a", total=7.0, count=2)
+        host.add_node("b", total=10, count=3)
+        host.add_edge("a", "b")
+
+        qry = """
+        MATCH (A)
+        WHERE A.total / A.count > 3.4
+        RETURN A.total
+        """
+        res = GrandCypher(host).run(qry)
+        assert res["A.total"] == [7.0]
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_addition_with_literal(self, graph_type):
+        host = graph_type()
+        host.add_node("a", value=5)
+        host.add_node("b", value=15)
+        host.add_edge("a", "b")
+
+        qry = """
+        MATCH (A)
+        WHERE A.value + 10 > 20
+        RETURN A.value
+        """
+        res = GrandCypher(host).run(qry)
+        assert res["A.value"] == [15]
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_modulo_in_where(self, graph_type):
+        host = graph_type()
+        host.add_node("a", value=4)
+        host.add_node("b", value=7)
+        host.add_node("c", value=10)
+        host.add_edge("a", "b")
+        host.add_edge("b", "c")
+
+        qry = """
+        MATCH (A)
+        WHERE A.value % 2 == 0
+        RETURN A.value
+        """
+        res = GrandCypher(host).run(qry)
+        assert set(res["A.value"]) == {4, 10}
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_parenthesized_arithmetic(self, graph_type):
+        host = graph_type()
+        host.add_node("a", x=3, y=2)
+        host.add_node("b", x=30, y=25)
+        host.add_edge("a", "b")
+
+        qry = """
+        MATCH (A)
+        WHERE (A.x + A.y) * 2 < 20
+        RETURN A.x
+        """
+        res = GrandCypher(host).run(qry)
+        assert res["A.x"] == [3]
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_non_numeric_properties_no_crash(self, graph_type):
+        host = graph_type()
+        host.add_node("a", value="hello")
+        host.add_node("b", value=10)
+        host.add_edge("a", "b")
+
+        qry = """
+        MATCH (A)
+        WHERE A.value + 1 > 5
+        RETURN A.value
+        """
+        res = GrandCypher(host).run(qry)
+        assert res["A.value"] == [10]
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_division_by_zero_no_crash(self, graph_type):
+        host = graph_type()
+        host.add_node("a", x=10, y=0)
+        host.add_node("b", x=10, y=2)
+        host.add_edge("a", "b")
+
+        qry = """
+        MATCH (A)
+        WHERE A.x / A.y > 1
+        RETURN A.x, A.y
+        """
+        res = GrandCypher(host).run(qry)
+        assert res["A.x"] == [10]
+        assert res["A.y"] == [2]
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_arithmetic_on_right_side(self, graph_type):
+        host = graph_type()
+        host.add_node("a", value=10, threshold=8)
+        host.add_node("b", value=10, threshold=12)
+        host.add_edge("a", "b")
+
+        qry = """
+        MATCH (A)
+        WHERE A.value > A.threshold - 5
+        RETURN A.value, A.threshold
+        """
+        res = GrandCypher(host).run(qry)
+        assert len(res["A.value"]) == 2
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_chained_arithmetic(self, graph_type):
+        host = graph_type()
+        host.add_node("a", x=10, y=3, z=2)
+        host.add_node("b", x=10, y=3, z=20)
+        host.add_edge("a", "b")
+
+        qry = """
+        MATCH (A)
+        WHERE A.x + A.y - A.z > 5
+        RETURN A.x
+        """
+        res = GrandCypher(host).run(qry)
+        assert res["A.x"] == [10]
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_nested_parenthesized_arithmetic(self, graph_type):
+        host = graph_type()
+        host.add_node("a", x=2, y=3)
+        host.add_node("b", x=10, y=1)
+        host.add_edge("a", "b")
+
+        qry = """
+        MATCH (A)
+        WHERE ((A.x + 1) * 2) - 3 > 10
+        RETURN A.x
+        """
+        res = GrandCypher(host).run(qry)
+        assert res["A.x"] == [10]
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_arithmetic_with_edge_attributes(self, graph_type):
+        host = graph_type()
+        host.add_node("a")
+        host.add_node("b")
+        host.add_edge("a", "b", weight=10, penalty=3)
+
+        qry = """
+        MATCH (A)-[E]->(B)
+        WHERE E.weight - E.penalty > 5
+        RETURN A, B
+        """
+        res = GrandCypher(host).run(qry)
+        assert len(res["A"]) == 1
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_arithmetic_with_id_function(self, graph_type):
+        host = graph_type()
+        host.add_node(1, value=10)
+        host.add_node(2, value=20)
+        host.add_node(3, value=30)
+        host.add_edge(1, 2)
+        host.add_edge(2, 3)
+
+        qry = """
+        MATCH (A)
+        WHERE ID(A) + 1 > 2
+        RETURN ID(A)
+        """
+        res = GrandCypher(host).run(qry)
+        assert set(res["ID(A)"]) == {2, 3}
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_arithmetic_missing_attribute(self, graph_type):
+        host = graph_type()
+        host.add_node("a", value=10)
+        host.add_node("b")
+        host.add_edge("a", "b")
+
+        qry = """
+        MATCH (A)
+        WHERE A.value + 1 > 5
+        RETURN A.value
+        """
+        res = GrandCypher(host).run(qry)
+        assert res["A.value"] == [10]
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_literal_string_with_dot_not_confused_with_entity(self, graph_type):
+        host = graph_type()
+        host.add_node("a", club="Mr. Hi")
+        host.add_node("b", club="Officer")
+        host.add_edge("a", "b")
+
+        qry = """
+        MATCH (A)
+        WHERE A.club == "Mr. Hi"
+        RETURN A.club
+        """
+        res = GrandCypher(host).run(qry)
+        assert res["A.club"] == ["Mr. Hi"]
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_literal_string_matching_entity_name_not_resolved(self, graph_type):
+        host = graph_type()
+        host.add_node("a", name="A.special", special="wrong")
+        host.add_node("b", name="other")
+        host.add_edge("a", "b")
+
+        qry = """
+        MATCH (A)
+        WHERE A.name == "A.special"
+        RETURN A.name
+        """
+        res = GrandCypher(host).run(qry)
+        assert res["A.name"] == ["A.special"]
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_unbound_entity_in_where_should_error(self, graph_type):
+        host = graph_type()
+        host.add_node("a", value=10)
+        host.add_node("b", value=20)
+        host.add_edge("a", "b")
+
+        qry = """
+        MATCH (A)-[]->(C)
+        WHERE B.value > 5
+        RETURN A.value
+        """
+        with pytest.raises(IndexError):
+            GrandCypher(host).run(qry)
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_arithmetic_with_and(self, graph_type):
+        host = graph_type()
+        host.add_node("a", x=10, y=3)
+        host.add_node("b", x=2, y=100)
+        host.add_node("c", x=10, y=100)
+        host.add_edge("a", "b")
+        host.add_edge("b", "c")
+
+        qry = """
+        MATCH (A)
+        WHERE A.x + 1 > 5 AND A.y * 2 < 20
+        RETURN A.x, A.y
+        """
+        res = GrandCypher(host).run(qry)
+        assert res["A.x"] == [10]
+        assert res["A.y"] == [3]
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_arithmetic_with_not(self, graph_type):
+        host = graph_type()
+        host.add_node("a", x=20, y=5)
+        host.add_node("b", x=3, y=1)
+        host.add_edge("a", "b")
+
+        qry = """
+        MATCH (A)
+        WHERE NOT A.x - A.y > 10
+        RETURN A.x
+        """
+        res = GrandCypher(host).run(qry)
+        assert res["A.x"] == [3]
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_cross_entity_arithmetic(self, graph_type):
+        host = graph_type()
+        host.add_node("a", x=20)
+        host.add_node("b", y=5)
+        host.add_node("c", y=18)
+        host.add_edge("a", "b")
+        host.add_edge("a", "c")
+
+        qry = """
+        MATCH (A)-[]->(B)
+        WHERE A.x - B.y > 5
+        RETURN A.x, B.y
+        """
+        res = GrandCypher(host).run(qry)
+        assert res["A.x"] == [20]
+        assert res["B.y"] == [5]
+
+    @pytest.mark.xfail(reason="bare entity names bypass entity_id() due to ? grammar prefix — silently returns empty instead of raising")
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_bare_entity_name_in_where_should_error(self, graph_type):
+        host = graph_type()
+        host.add_node(1, value=10)
+        host.add_node(2, value=20)
+        host.add_edge(1, 2)
+
+        qry = """
+        MATCH (A)
+        WHERE A + 0 > 1
+        RETURN ID(A)
+        """
+        with pytest.raises(TypeError):
+            GrandCypher(host).run(qry)

--- a/grandcypher/test_queries.py
+++ b/grandcypher/test_queries.py
@@ -2783,6 +2783,20 @@ class TestArithmeticExpressions:
         assert set(res["A.total"]) == {7, 10}
 
     @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_negative_integer_division_truncates_toward_zero(self, graph_type):
+        host = graph_type()
+        host.add_node("a", value=-7, divisor=2)
+        host.add_edge("a", "a")
+
+        qry = """
+        MATCH (A)
+        WHERE A.value / A.divisor == -3
+        RETURN A.value
+        """
+        res = GrandCypher(host).run(qry)
+        assert res["A.value"] == [-7]
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
     def test_float_division_in_where(self, graph_type):
         host = graph_type()
         host.add_node("a", total=7.0, count=2)

--- a/grandcypher/test_queries.py
+++ b/grandcypher/test_queries.py
@@ -3078,3 +3078,21 @@ class TestArithmeticExpressions:
         """
         with pytest.raises(TypeError):
             GrandCypher(host).run(qry)
+
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_id_inequality_in_where(self, graph_type):
+        host = graph_type()
+        host.add_node(1, name="Alice")
+        host.add_node(2, name="Bob")
+        host.add_node(3, name="Charlie")
+        host.add_edge(1, 2)
+        host.add_edge(2, 3)
+
+        res = GrandCypher(host).run("MATCH (A) WHERE ID(A) > 1 RETURN A.name")
+        assert res["A.name"] == ["Bob", "Charlie"]
+
+        res = GrandCypher(host).run("MATCH (A) WHERE ID(A) >= 2 RETURN A.name")
+        assert res["A.name"] == ["Bob", "Charlie"]
+
+        res = GrandCypher(host).run("MATCH (A) WHERE ID(A) < 3 RETURN A.name")
+        assert res["A.name"] == ["Alice", "Bob"]

--- a/grandcypher/test_to_indexer_ast.py
+++ b/grandcypher/test_to_indexer_ast.py
@@ -1,6 +1,9 @@
 from . import (
+    ArithmeticExpression,
     Condition,
     CompoundCondition,
+    EntityRef,
+    IDRef,
     LambdaCompareCondition,
     AND,
     OR,
@@ -51,9 +54,9 @@ def test_compound_condition_unwraps_into_compare():
     inner = LambdaCompareCondition(lambda x,y: True, "<")
     comp = CompoundCondition(
         should_be=True,
-        entity_id="B.height",
+        left="B.height",
         operator=inner,
-        value=200,
+        right=200,
     )
 
     ast = to_indexer_ast(comp)
@@ -146,3 +149,60 @@ def test_exists_subquery_returns_skip():
     ast = to_indexer_ast(cond)
 
     assert isinstance(ast, UnsupportedOp)
+
+
+# === 8. ArithmeticExpression in left/right → UnsupportedOp ===
+
+def test_arithmetic_left_returns_unsupportedop():
+    arith = ArithmeticExpression("A.x", "-", "A.y")
+    cond = CompoundCondition(
+        should_be=True,
+        left=arith,
+        operator=make_lambda_compare("<"),
+        right=50,
+    )
+
+    ast = to_indexer_ast(cond)
+    assert isinstance(ast, UnsupportedOp)
+
+
+def test_arithmetic_value_returns_unsupportedop():
+    arith = ArithmeticExpression("A.x", "+", 10)
+    cond = CompoundCondition(
+        should_be=True,
+        left="A.total",
+        operator=make_lambda_compare(">"),
+        right=arith,
+    )
+
+    ast = to_indexer_ast(cond)
+    assert isinstance(ast, UnsupportedOp)
+
+
+def test_arithmetic_in_and_returns_unsupportedop_branch():
+    arith = ArithmeticExpression("A.x", "*", "A.y")
+    left = CompoundCondition(True, arith, make_lambda_compare(">"), 100)
+    right = CompoundCondition(True, "B.score", make_lambda_compare("<"), 5)
+
+    cond = AND(left, right)
+    ast = to_indexer_ast(cond)
+
+    assert isinstance(ast, IndexerAnd)
+    assert isinstance(ast._a, UnsupportedOp)
+    assert isinstance(ast._b, IndexerCompare)
+
+
+# === 9. IDRef strips to entity_name ===
+
+def test_id_ref_entity_strips_to_entity_name():
+    cond = CompoundCondition(
+        should_be=True,
+        left=IDRef("A"),
+        operator=make_lambda_compare(">"),
+        right=5,
+    )
+
+    ast = to_indexer_ast(cond)
+    assert isinstance(ast, IndexerCompare)
+    assert ast._key == "A"
+    assert ast._value == 5

--- a/grandcypher/test_to_indexer_ast.py
+++ b/grandcypher/test_to_indexer_ast.py
@@ -192,9 +192,9 @@ def test_arithmetic_in_and_returns_unsupportedop_branch():
     assert isinstance(ast._b, IndexerCompare)
 
 
-# === 9. IDRef strips to entity_name ===
+# === 9. IDRef → UnsupportedOp (indexer cannot filter by node ID) ===
 
-def test_id_ref_entity_strips_to_entity_name():
+def test_id_ref_returns_unsupportedop():
     cond = CompoundCondition(
         should_be=True,
         left=IDRef("A"),
@@ -203,6 +203,4 @@ def test_id_ref_entity_strips_to_entity_name():
     )
 
     ast = to_indexer_ast(cond)
-    assert isinstance(ast, IndexerCompare)
-    assert ast._key == "A"
-    assert ast._value == 5
+    assert isinstance(ast, UnsupportedOp)

--- a/grandcypher/test_to_indexer_ast.py
+++ b/grandcypher/test_to_indexer_ast.py
@@ -1,5 +1,6 @@
 from . import (
     ArithmeticExpression,
+    AttributeRef,
     Condition,
     CompoundCondition,
     EntityRef,
@@ -37,14 +38,14 @@ def make_lambda_compare(op_str):
 
 def test_simple_compare_to_indexer_ast():
     cond = LambdaCompareCondition(lambda x,y: True, ">")
-    entity = "A.age"
+    entity = AttributeRef("A", "age")
     value = 10
 
     ast = to_indexer_ast(cond, entity, value)
 
     assert isinstance(ast, IndexerCompare)
     assert ast._op == ">"
-    assert ast._key == "A.age"
+    assert ast._key == AttributeRef("A", "age")
     assert ast._value == 10
 
 
@@ -54,7 +55,7 @@ def test_compound_condition_unwraps_into_compare():
     inner = LambdaCompareCondition(lambda x,y: True, "<")
     comp = CompoundCondition(
         should_be=True,
-        left="B.height",
+        left=AttributeRef("B", "height"),
         operator=inner,
         right=200,
     )
@@ -63,7 +64,7 @@ def test_compound_condition_unwraps_into_compare():
 
     assert isinstance(ast, IndexerCompare)
     assert ast._op == "<"
-    assert ast._key == "B.height"
+    assert ast._key == AttributeRef("B", "height")
     assert ast._value == 200
 
 
@@ -74,8 +75,8 @@ def test_and_becomes_indexer_and():
     right = LambdaCompareCondition(lambda x,y: True, "<")
 
     cond = AND(
-        CompoundCondition(True, "A.age", left, 10),
-        CompoundCondition(True, "B.score", right, 5),
+        CompoundCondition(True, AttributeRef("A", "age"), left, 10),
+        CompoundCondition(True, AttributeRef("B", "score"), right, 5),
     )
 
     ast = to_indexer_ast(cond)
@@ -84,8 +85,8 @@ def test_and_becomes_indexer_and():
     assert isinstance(ast._a, IndexerCompare)
     assert isinstance(ast._b, IndexerCompare)
 
-    assert ast._a._key == "A.age"
-    assert ast._b._key == "B.score"
+    assert ast._a._key == AttributeRef("A", "age")
+    assert ast._b._key == AttributeRef("B", "score")
 
 
 # === 4. OR maps to IndexerOr ======================
@@ -95,8 +96,8 @@ def test_or_becomes_indexer_or():
     right = LambdaCompareCondition(lambda x,y: True, "<")
 
     cond = OR(
-        CompoundCondition(True, "A.age", left, 10),
-        CompoundCondition(True, "A.age", right, 200),
+        CompoundCondition(True, AttributeRef("A", "age"), left, 10),
+        CompoundCondition(True, AttributeRef("A", "age"), right, 200),
     )
 
     ast = to_indexer_ast(cond)
@@ -109,9 +110,9 @@ def test_or_becomes_indexer_or():
 # === 5. Nested AND/OR =============================
 
 def test_nested_ast():
-    c1 = CompoundCondition(True, "A.age", make_lambda_compare(">"), 10)
-    c2 = CompoundCondition(True, "B.score", make_lambda_compare("<"), 100)
-    c3 = CompoundCondition(True, "A.age", make_lambda_compare(">"), 30)
+    c1 = CompoundCondition(True, AttributeRef("A", "age"), make_lambda_compare(">"), 10)
+    c2 = CompoundCondition(True, AttributeRef("B", "score"), make_lambda_compare("<"), 100)
+    c3 = CompoundCondition(True, AttributeRef("A", "age"), make_lambda_compare(">"), 30)
 
     cond = AND(
         c1,
@@ -151,38 +152,93 @@ def test_exists_subquery_returns_skip():
     assert isinstance(ast, UnsupportedOp)
 
 
-# === 8. ArithmeticExpression in left/right → UnsupportedOp ===
+# === 8. IndexerCompare only for AttributeRef left + literal right ===
+
+def test_attribute_ref_with_literal_produces_compare():
+    cond = CompoundCondition(
+        should_be=True,
+        left=AttributeRef("A", "age"),
+        operator=make_lambda_compare(">"),
+        right=30,
+    )
+    ast = to_indexer_ast(cond)
+    assert isinstance(ast, IndexerCompare)
+    assert ast._key == AttributeRef("A", "age")
+    assert ast._value == 30
+
+
+def test_bare_entity_ref_left_returns_unsupportedop():
+    cond = CompoundCondition(
+        should_be=True,
+        left=EntityRef("A"),
+        operator=make_lambda_compare(">"),
+        right=5,
+    )
+    ast = to_indexer_ast(cond)
+    assert isinstance(ast, UnsupportedOp)
+
+
+def test_literal_left_attribute_ref_right_returns_unsupportedop():
+    cond = CompoundCondition(
+        should_be=True,
+        left=100,
+        operator=make_lambda_compare("<"),
+        right=AttributeRef("A", "age"),
+    )
+    ast = to_indexer_ast(cond)
+    assert isinstance(ast, UnsupportedOp)
+
 
 def test_arithmetic_left_returns_unsupportedop():
-    arith = ArithmeticExpression("A.x", "-", "A.y")
+    arith = ArithmeticExpression(AttributeRef("A", "x"), "-", AttributeRef("A", "y"))
     cond = CompoundCondition(
         should_be=True,
         left=arith,
         operator=make_lambda_compare("<"),
         right=50,
     )
-
     ast = to_indexer_ast(cond)
     assert isinstance(ast, UnsupportedOp)
 
 
-def test_arithmetic_value_returns_unsupportedop():
-    arith = ArithmeticExpression("A.x", "+", 10)
+def test_arithmetic_right_returns_unsupportedop():
+    arith = ArithmeticExpression(AttributeRef("A", "x"), "+", 10)
     cond = CompoundCondition(
         should_be=True,
-        left="A.total",
+        left=AttributeRef("A", "total"),
         operator=make_lambda_compare(">"),
         right=arith,
     )
-
     ast = to_indexer_ast(cond)
     assert isinstance(ast, UnsupportedOp)
 
 
-def test_arithmetic_in_and_returns_unsupportedop_branch():
-    arith = ArithmeticExpression("A.x", "*", "A.y")
+def test_id_ref_left_returns_unsupportedop():
+    cond = CompoundCondition(
+        should_be=True,
+        left=IDRef("A"),
+        operator=make_lambda_compare(">"),
+        right=5,
+    )
+    ast = to_indexer_ast(cond)
+    assert isinstance(ast, UnsupportedOp)
+
+
+def test_id_ref_right_returns_unsupportedop():
+    cond = CompoundCondition(
+        should_be=True,
+        left=5,
+        operator=make_lambda_compare("<"),
+        right=IDRef("A"),
+    )
+    ast = to_indexer_ast(cond)
+    assert isinstance(ast, UnsupportedOp)
+
+
+def test_arithmetic_in_and_unsupported_branch():
+    arith = ArithmeticExpression(AttributeRef("A", "x"), "*", AttributeRef("A", "y"))
     left = CompoundCondition(True, arith, make_lambda_compare(">"), 100)
-    right = CompoundCondition(True, "B.score", make_lambda_compare("<"), 5)
+    right = CompoundCondition(True, AttributeRef("B", "score"), make_lambda_compare("<"), 5)
 
     cond = AND(left, right)
     ast = to_indexer_ast(cond)
@@ -190,17 +246,3 @@ def test_arithmetic_in_and_returns_unsupportedop_branch():
     assert isinstance(ast, IndexerAnd)
     assert isinstance(ast._a, UnsupportedOp)
     assert isinstance(ast._b, IndexerCompare)
-
-
-# === 9. IDRef → UnsupportedOp (indexer cannot filter by node ID) ===
-
-def test_id_ref_returns_unsupportedop():
-    cond = CompoundCondition(
-        should_be=True,
-        left=IDRef("A"),
-        operator=make_lambda_compare(">"),
-        right=5,
-    )
-
-    ast = to_indexer_ast(cond)
-    assert isinstance(ast, UnsupportedOp)

--- a/grandcypher/test_to_indexer_ast.py
+++ b/grandcypher/test_to_indexer_ast.py
@@ -213,7 +213,20 @@ def test_arithmetic_right_returns_unsupportedop():
     assert isinstance(ast, UnsupportedOp)
 
 
-def test_id_ref_left_returns_unsupportedop():
+def test_id_ref_equality_produces_compare():
+    cond = CompoundCondition(
+        should_be=True,
+        left=IDRef("A"),
+        operator=make_lambda_compare("=="),
+        right=5,
+    )
+    ast = to_indexer_ast(cond)
+    assert isinstance(ast, IndexerCompare)
+    assert ast._key == IDRef("A")
+    assert ast._value == 5
+
+
+def test_id_ref_inequality_returns_unsupportedop():
     cond = CompoundCondition(
         should_be=True,
         left=IDRef("A"),

--- a/grandcypher/types.py
+++ b/grandcypher/types.py
@@ -1,0 +1,38 @@
+"""Typed operand classes for GrandCypher query processing."""
+
+
+class EntityRef(str):
+    """Bare node/edge reference, e.g. A.
+
+    str subclass because the RETURN path uses these as dict keys
+    and passes them through isinstance(item, str) checks.
+    """
+    def __new__(cls, entity_name):
+        instance = super().__new__(cls, str(entity_name))
+        instance.entity_name = str(entity_name)
+        return instance
+
+
+class AttributeRef(str):
+    """Node/edge attribute reference, e.g. A.age.
+
+    str subclass because the RETURN path uses these as dict keys
+    and passes them through isinstance(item, str) checks.
+    """
+    def __new__(cls, entity_name, attribute):
+        instance = super().__new__(cls, f"{entity_name}.{attribute}")
+        instance.entity_name = str(entity_name)
+        instance.attribute = str(attribute)
+        return instance
+
+
+class IDRef(str):
+    """Reference to ID(A) in WHERE clauses.
+
+    str subclass because the RETURN path uses these as dict keys
+    and passes them through isinstance(item, str) checks.
+    """
+    def __new__(cls, entity_name):
+        instance = super().__new__(cls, f"ID({entity_name})")
+        instance.entity_name = str(entity_name)
+        return instance

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,15 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
+
+[[package]]
+name = "cachetools"
+version = "7.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/c1/67cfb86aa21144796ff51068326d467fbef8ee42f8d08a3a8a926106cf0c/cachetools-7.1.3.tar.gz", hash = "sha256:135cfe944bc3c1e805505f65dae0bef375a2f96261171ab66c79ef77d0bda39d", size = 45780, upload-time = "2026-05-18T18:21:03.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/52/8ff5c1a3b2e821ced9b2998fba3ee29aa4525c0bf51e5ee55dd6f61a4ed5/cachetools-7.1.3-py3-none-any.whl", hash = "sha256:9876787e2346e20584d5cca236cb5d49d04e7193de91646f230725b2e1e8b804", size = 16763, upload-time = "2026-05-18T18:21:02.386Z" },
+]
 
 [[package]]
 name = "colorama"
@@ -25,9 +34,10 @@ wheels = [
 
 [[package]]
 name = "grand-cypher"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
+    { name = "cachetools" },
     { name = "grandiso" },
     { name = "lark" },
     { name = "networkx" },
@@ -41,6 +51,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cachetools", specifier = ">=6.2.1" },
     { name = "grandiso", specifier = ">=2.2.0" },
     { name = "lark", specifier = ">=1.2.2" },
     { name = "networkx", specifier = ">=3.4.2" },


### PR DESCRIPTION
## Summary

Adds support for arithmetic operators (`+`, `-`, `*`, `/`, `%`) in WHERE clauses, enabling queries like:

```cypher
MATCH (A)-[E]->(B)
WHERE A.price * A.qty > 100
  AND (B.revenue - B.costs) / B.headcount >= 50
RETURN A, B
```

## Changes

### Grammar (`_GrandCypherGrammar`)

The `condition` rule previously accepted only `entity_id op entity_id_or_value`. It now accepts `arith_expr op arith_expr`, where `arith_expr` is a two-level precedence grammar:

- **`arith_expr`** — handles `+` / `-` (lower precedence)
- **`arith_term`** — handles `*` / `/` / `%` (higher precedence)
- **`arith_atom`** — leaf nodes: `entity_id`, `scalar_function`, `value`, `NULL`, `TRUE`, `FALSE`, or a parenthesized sub-expression

The `IN` operator intentionally keeps its old rule (`entity_id op_list value_list`) — arithmetic on the LHS of `IN` is not supported by design.

### Typed operand classes: `EntityRef`, `AttributeRef`, `IDRef`, `ArithmeticExpression`

The old code represented all entity references as plain strings (`"A"`, `"A.age"`) and ID lookups as string patterns (`"ID(A)"`). This made it impossible to distinguish operand types at evaluation time and required fragile string-parsing (e.g. `startswith("ID(")`, `split(".")`) throughout `CompoundCondition.__call__` and the indexer.

Four typed classes replace this:

- **`EntityRef(str)`** — bare node/edge reference, e.g. `A`. Raises `TypeError` if used in a WHERE comparison, since bare entities aren't meaningful in comparisons.
- **`AttributeRef(str)`** — node/edge attribute reference, e.g. `A.age`, with `.entity_name` and `.attribute` accessors.
- **`IDRef(str)`** — `ID(A)` reference with `.entity_name` accessor.
- **`ArithmeticExpression`** — recursive tree node (`left`, `op`, `right`) with a `.resolve()` method for evaluation.

All `str` subclasses retain string equality and dict-key compatibility.

### Operand resolution: `_resolve_operand()`

A single recursive function replaces the scattered resolution logic that was previously inlined in `CompoundCondition.__call__`. It dispatches on operand type:

- **`ArithmeticExpression`** — recursively resolves via `.resolve()`
- **`IDRef`** — looks up the node ID from the match mapping
- **`AttributeRef`** — looks up the node/edge attribute from the host graph
- **`EntityRef`** — raises `TypeError` (bare entities are not valid in comparisons)
- **Anything else** — returned as a literal value

### `CompoundCondition` refactor

Constructor parameters renamed from `entity_id` / `value` to `left` / `right` to reflect that either side of a comparison can now be an arbitrary expression, not just an entity reference or a literal.

The `__call__` method is simplified from ~30 lines of branching string-inspection to a short delegation to `_resolve_operand()`.

### Division semantics

Integer division (`//`) is used when both operands are integers, matching Neo4j/Cypher semantics. Float division is used otherwise.

### Error handling

`ArithmeticExpression.resolve()` catches `TypeError`, `ZeroDivisionError`, and `OverflowError`, returning `None`. `CompoundCondition` treats `None` as `False`, so rows with non-numeric attributes or division by zero are silently excluded rather than crashing.

### Indexer (`to_indexer_ast` and `Compare`)

`to_indexer_ast` creates `IndexerCompare` for two patterns:

- **`AttributeRef op literal`** — the standard case, e.g. `WHERE A.age > 20`. `Compare.__call__` uses `self._key.attribute` and `self._key.entity_name` directly to query the node attribute index.
- **`IDRef == literal`** — e.g. `WHERE ID(A) == 2`. `Compare.__call__` returns `{entity_name: {value}}` directly, restricting grandiso to that single node ID. Only equality is supported; inequality operators on `IDRef` fall through to `IndexerUnsupportedOp` for full-scan evaluation.

All other combinations fall through to `IndexerUnsupportedOp`.

`motif_to_indexer_ast` uses `AttributeRef` when building indexer keys.

### Return path (`_return_requests` coercion)

The old `list(map(str, self._return_requests))` line stripped Lark `Token` wrappers to plain strings. With typed operand classes now in play, a blanket `str()` conversion destroys the type information that `_lookup` relies on (e.g. `isinstance(data_path, IDRef)`). The coercion is now type-aware: `EntityRef`, `AttributeRef`, and `IDRef` are preserved, everything else is converted to `str`.

## Bugfix: `ID()` comparisons with inequality operators

The old `to_indexer_ast` had a dead branch — `entity_id.startswith("ID()")` (note the empty parens) never matched actual strings like `"ID(A)"`, so `ID()` conditions always fell through to `IndexerUnsupportedOp`, triggering a full scan. This happened to produce correct results because the full-scan path evaluated the comparison properly.

The dead branch was intended to strip `ID(A)` down to `A` and pass it to the indexer's `Compare` class, where the single-element key path (key with no dot) would handle it. However, that `Compare` path also had a latent bug: it ignored the operator entirely and treated every comparison as equality. For example, `WHERE ID(A) > 1` on a graph with nodes 1, 2, 3 would pass key `"A"`, op `">"`, value `1` to `Compare`. The single-element branch would ignore `">"` and return `{"A": {1}}` — telling the executor to only consider node 1 for entity A. Nodes 2 and 3 would never be evaluated. The WHERE condition would then check `1 > 1` on the sole candidate, which is false, producing an empty result set.

We have removed both the dead branch in `to_indexer_ast` and the single-element key path in `Compare`, since neither was ever reached and the latter doesn't work correctly. `ID()` conditions are now handled by the typed operand approach: `to_indexer_ast` routes `IDRef == literal` to `IndexerCompare` for indexed lookup, preserving the `==` optimisation that the original code intended. Inequality operators like `WHERE ID(A) > 1`, which would have produced wrong results if the dead branch had been reached, are routed to `IndexerUnsupportedOp` for correct full-scan evaluation.

## Known issue: bare entity names in WHERE

`test_bare_entity_name_in_where_should_error` is marked `xfail`. A query like `WHERE A + 0 > 1` (using a bare entity name `A` rather than an attribute like `A.age`) should raise a `TypeError`, but currently silently returns empty results. This happens because the `?` prefix on the `entity_id` grammar rule inlines bare `CNAME` tokens directly, bypassing the `entity_id` transformer method. The bare `A` arrives as a raw Lark `Token` rather than an `EntityRef`, so `_resolve_operand` treats it as a literal string value instead of raising. Fixing this would require either removing the `?` prefix (which affects all grammar rules that reference `entity_id`) or adding a validation pass after transformation. This was an existing issue which is not yet fixed.

## Tests

- **`test_queries.py`** — 23 new end-to-end tests covering all operators, precedence, parentheses, edge attributes, `ID()` equality and inequality, chained expressions, error resilience (non-numeric, division by zero, missing attributes), `AND`/`NOT` combinations, and cross-entity arithmetic.
- **`test_parser.py`** — 10 new parser tests verifying parse tree structure (correct `arith_*` node types, operator nodes, literal values), not just that parsing doesn't crash.
- **`test_to_indexer_ast.py`** — 9 new tests covering positive routing (`AttributeRef` + literal → `IndexerCompare`, `IDRef` + `==` + literal → `IndexerCompare`) and negative routing (bare `EntityRef`, swapped operands, `ArithmeticExpression` on either side, `IDRef` with inequality → `UnsupportedOp`).
- **`test_indexer_plumbing.py`** — 7 new plumbing tests that mock `grandiso.find_motifs_iter` to verify the indexer produces correct hints end-to-end: attribute equality/inequality, entity scoping, `ID()` equality producing hints, `ID()` inequality/arithmetic/edge attributes falling back to no hints.
- **`test_indexer.py`** — updated `Compare` tests to use `AttributeRef` keys instead of plain strings.
