### PR TITLE
make return types picklable

### DIFF
--- a/grandcypher/test_types.py
+++ b/grandcypher/test_types.py
@@ -1,0 +1,54 @@
+import pickle
+
+import networkx as nx
+
+from grandcypher import GrandCypher
+from grandcypher.types import AttributeRef, IDRef, EntityRef
+
+
+def test_attribute_ref_pickle_roundtrip():
+    ref = AttributeRef('a', 'name')
+    restored = pickle.loads(pickle.dumps(ref))
+    assert restored == 'a.name'
+    assert type(restored) is AttributeRef
+    assert restored.entity_name == 'a'
+    assert restored.attribute == 'name'
+
+
+def test_id_ref_pickle_roundtrip():
+    ref = IDRef('a')
+    restored = pickle.loads(pickle.dumps(ref))
+    assert restored == 'ID(a)'
+    assert type(restored) is IDRef
+    assert restored.entity_name == 'a'
+
+
+def test_entity_ref_pickle_roundtrip():
+    ref = EntityRef('a')
+    restored = pickle.loads(pickle.dumps(ref))
+    assert restored == 'a'
+    assert type(restored) is EntityRef
+    assert restored.entity_name == 'a'
+
+
+def test_query_results_pickle_roundtrip():
+    host = nx.DiGraph()
+    host.add_node("x", name="Alice", age=30)
+    host.add_node("y", name="Bob", age=25)
+    host.add_edge("x", "y", since=2020)
+
+    qry = """
+    MATCH (A)-[E]->(B)
+    WHERE A.name == "Alice"
+    RETURN A, A.name, A.age, ID(A), B
+    """
+
+    results = GrandCypher(host).run(qry)
+    restored = pickle.loads(pickle.dumps(results))
+
+    assert restored == results
+    for key in results:
+        assert type(restored[key]) is type(results[key])
+    for key in restored:
+        restored_key_type = type(key)
+        assert any(type(k) is restored_key_type for k in results)

--- a/grandcypher/types.py
+++ b/grandcypher/types.py
@@ -12,6 +12,9 @@ class EntityRef(str):
         instance.entity_name = str(entity_name)
         return instance
 
+    def __getnewargs__(self):
+        return (self.entity_name,)
+
 
 class AttributeRef(str):
     """Node/edge attribute reference, e.g. A.age.
@@ -25,6 +28,9 @@ class AttributeRef(str):
         instance.attribute = str(attribute)
         return instance
 
+    def __getnewargs__(self):
+        return (self.entity_name, self.attribute)
+
 
 class IDRef(str):
     """Reference to ID(A) in WHERE clauses.
@@ -36,3 +42,6 @@ class IDRef(str):
         instance = super().__new__(cls, f"ID({entity_name})")
         instance.entity_name = str(entity_name)
         return instance
+
+    def __getnewargs__(self):
+        return (self.entity_name,)


### PR DESCRIPTION
This is a quick one to help anyone using GrandCypher results downstream.

# Fix pickling of query result keys (`AttributeRef`, `IDRef`, `EntityRef`)

## Problem

The `str` subclasses in `grandcypher/types.py` that are used as result dictionary keys don't survive pickle round-trips. This breaks any downstream code that serialises GrandCypher query results — e.g. PySpark `map()`, `multiprocessing`, `joblib`, or caching.

**`AttributeRef` — crashes on unpickle:**

`AttributeRef.__new__` takes two arguments (`entity_name`, `attribute`), but pickle's default `str` reconstruction only passes the single string value:

```python
>>> pickle.loads(pickle.dumps(AttributeRef('a', 'name')))
TypeError: AttributeRef.__new__() missing 1 required positional argument: 'attribute'
```

**`IDRef` — silently corrupts on unpickle:**

`IDRef.__new__` wraps its argument as `f"ID({entity_name})"`. Pickle reconstructs with `str(self)` which is already `"ID(a)"`, so `__new__` wraps it again:

```python
>>> pickle.loads(pickle.dumps(IDRef('a')))
'ID(ID(a))'
```

## Root cause

Python's `str` pickle path calls `cls.__new__(cls, str_value)` on unpickle. This works when `__new__` takes exactly one argument matching the string value (as with `EntityRef`), but breaks when:

- `__new__` takes extra arguments (`AttributeRef`)
- `__new__` transforms the argument (`IDRef` prepends `"ID("`)

## Fix

Added `__getnewargs__` to all three ref classes (`AttributeRef`, `IDRef`, `EntityRef`). This method tells pickle which arguments to pass to `__new__` during reconstruction, so the original constructor arguments are preserved across serialisation.

## Changes

- **`grandcypher/types.py`** — added `__getnewargs__` to `EntityRef`, `AttributeRef`, and `IDRef`
- **`grandcypher/test_types.py`** (new) — pickle round-trip tests for each ref class individually, plus an end-to-end test that pickles the full result dict from a `GrandCypher.run()` query
