### PR TITLE
Fix #101: RETURN bare node alongside ID(node) no longer clobbers the node

### DIFF
--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -923,9 +923,7 @@ class GrandCypherExecutor:
                 if original_entity in motif_nodes:
                     ret = [match.mth.node(original_entity) for match in true_matches]
                     result[data_path] = ret[offset_limit]
-                    result[original_entity] = ret[offset_limit]
                     processed_paths.add(data_path)
-                    processed_paths.add(original_entity)
                     continue
             else:
                 entity_name, _ = _data_path_to_entity_name_attribute(data_path)

--- a/grandcypher/test_queries.py
+++ b/grandcypher/test_queries.py
@@ -2556,6 +2556,30 @@ class TestReturnFullNodeAttributes:
         # B.name should be just the attribute value
         assert result["B.name"][0] == "node_y"
 
+    @pytest.mark.parametrize("graph_type", ACCEPTED_GRAPH_TYPES)
+    def test_return_bare_node_and_id_together(self, graph_type):
+        """RETURN of a bare node alongside ID(node) should not clobber the node.
+
+        Regression test for issue #101: the ID() handler used to store its
+        result under both "ID(a)" and the bare "a" key (and mark "a" as
+        processed), so `RETURN a, ID(a)` returned the node id string for `a`
+        instead of the node's attribute dictionary.
+        """
+        host = graph_type()
+        host.add_node("alice", name="Alice", age=30)
+        host.add_node("bob", name="Bob", age=25)
+        host.add_edge("alice", "bob", relationship="knows")
+
+        # Bare node first, then ID()
+        result = GrandCypher(host).run("MATCH (a)-[]->(b) RETURN a, ID(a)")
+        assert result["a"] == [{"name": "Alice", "age": 30}]
+        assert result["ID(a)"] == ["alice"]
+
+        # ID() first, then bare node — ordering must not matter
+        result = GrandCypher(host).run("MATCH (a)-[]->(b) RETURN ID(a), a")
+        assert result["a"] == [{"name": "Alice", "age": 30}]
+        assert result["ID(a)"] == ["alice"]
+
 
 def test_generate_multiedge_edge_hop_key():
     edge_hop_map = {("A", "C"): ("A", "B", "C"), ("D", "E"): ("D", "D"), ("F", "G"): ("F", "G")}


### PR DESCRIPTION
## Summary

Fixes #101.

When a `RETURN` clause included both a bare node variable (`a`) and `ID(a)`, the bare node returned the node id string instead of the node's attribute dictionary:

```python
GrandCypher(G).run("MATCH (a)-[]->(b) RETURN a, ID(a)")
# a     -> ['alice']            # BUG: should be [{'name': 'Alice', 'age': 30}]
# ID(a) -> ['alice']
```

## Root cause

The `ID()` handler in `GrandCypherExecutor._lookup` stored its result under **both** the `"ID(a)"` key and the bare `"a"` key, and marked **both** as processed. So the bare node's slot was overwritten with the id string, and the main lookup loop then skipped `"a"` because it was already in `processed_paths`.

## Fix

Only store the result under the `IDRef` key and only mark the `IDRef` as processed, so a bare node in the same `RETURN` is evaluated normally. This removes the accidental early-days aliasing of `A` -> `ID(A)` that the maintainer confirmed in the issue is safe to remove.

## Tests

- Added `TestReturnFullNodeAttributes::test_return_bare_node_and_id_together`, parametrized over both accepted graph types, asserting `a` returns the attribute dict and `ID(a)` returns the id — in both `a, ID(a)` and `ID(a), a` orderings.
- Verified the new test fails without the fix and passes with it.
- Full suite: 431 passed, 2 xfailed (was 429 passed; +2 are the new parametrized cases).