### PR TITLE
Add scalar query functions

### DIFF
--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -96,14 +96,27 @@ op_list             : "in"i -> op_in
 
 
 return_clause       : "return"i distinct_return? return_item ("," return_item)*
-return_item         : (entity_id | aggregation_function | scalar_function | entity_id "." attribute_id) ( "AS"i alias )?
+return_item         : (entity_id | aggregation_function | scalar_function) ( "AS"i alias )?
 alias               : CNAME
 
 aggregation_function : AGGREGATE_FUNC "(" entity_id ( "." attribute_id )? ")"
 AGGREGATE_FUNC       : "COUNT" | "SUM" | "AVG" | "MAX" | "MIN"
 attribute_id         : CNAME
 
-scalar_function      : "id"i "(" entity_id ")" -> id_function
+?scalar_function     : "id"i "(" entity_id ")" -> id_function
+                    | "toLower"i "(" expression_argument ")" -> tolower_function
+                    | "toUpper"i "(" expression_argument ")" -> toupper_function
+                    | "trim"i "(" expression_argument ")" -> trim_function
+                    | "coalesce"i "(" expression_argument ("," expression_argument)+ ")" -> coalesce_function
+                    | "size"i "(" expression_argument ")" -> size_function
+                    | "type"i "(" entity_id ")" -> type_function
+
+?expression_argument : scalar_function
+                     | entity_id
+                     | value
+                     | NULL -> null
+                     | TRUE -> true
+                     | FALSE -> false
 
 distinct_return     : "DISTINCT"i
 limit_clause        : "limit"i NUMBER
@@ -245,6 +258,18 @@ _ARITH_OPS = {
 }
 
 
+def _lower(value):
+    return value.lower()
+
+
+def _upper(value):
+    return value.upper()
+
+
+def _strip(value):
+    return value.strip()
+
+
 class ArithmeticExpression:
     def __init__(self, left, op: str, right):
         self.left = left
@@ -261,6 +286,68 @@ class ArithmeticExpression:
 
     def __str__(self):
         return f"({self.left} {self.op} {self.right})"
+
+
+class ScalarFunctionExpression:
+    def __init__(self, name, argument, function):
+        self.name = name
+        self.argument = argument
+        self.function = function
+
+    def evaluate(self, match, host, return_edges, scope=None):
+        value = _evaluate_expression(self.argument, match, host, return_edges, scope)
+        return self.function(value) if value is not None else None
+
+    def __str__(self):
+        argument = getattr(self, "argument_display", self.argument)
+        return f"{self.name}({argument})"
+
+
+class CoalesceExpression:
+    def __init__(self, arguments):
+        self.arguments = arguments
+
+    def evaluate(self, match, host, return_edges, scope=None):
+        for argument in self.arguments:
+            value = _evaluate_expression(argument, match, host, return_edges, scope)
+            if value is not None:
+                return value
+        return None
+
+    def __str__(self):
+        return f"coalesce({', '.join(_format_expression(arg) for arg in self.arguments)})"
+
+
+class TypeExpression:
+    def __init__(self, argument):
+        self.argument = argument
+
+    def evaluate(self, match, host, return_edges, scope=None):
+        if self.argument not in return_edges:
+            return None
+        motif_edge = return_edges[self.argument]
+        edge_path = match.mth.edge(*motif_edge)
+        if not edge_path.edges:
+            return None
+        edge = edge_path.edges[-1]
+        edge_id = (edge.u, edge.v, edge.k) if host.is_multigraph() else (edge.u, edge.v)
+        labels = host.edges[edge_id].get("__labels__", set())
+        return next(iter(labels), None) if isinstance(labels, set) else labels
+
+    def __str__(self):
+        return f"type({self.argument})"
+
+
+def _evaluate_expression(value, match, host, return_edges, scope=None):
+    if isinstance(value, Expression):
+        return value.evaluate(match, host, return_edges, scope)
+    return value
+
+
+def _format_expression(value):
+    if isinstance(value, str) and not isinstance(value, Expression):
+        return f'"{value}"'
+    return str(value)
 
 
 def _resolve_operand(operand, match, host, return_edges):
@@ -896,8 +983,22 @@ class GrandCypherExecutor:
         result = {}
         processed_paths = set()  # Keep track of processed paths
 
+        for data_path in data_paths:
+            if isinstance(data_path, Expression) and not isinstance(
+                data_path, (EntityRef, AttributeRef, IDRef)
+            ):
+                result[str(data_path)] = [
+                    data_path.evaluate(
+                        match, self._target_graph, self._return_edges
+                    )
+                    for match in true_matches
+                ][offset_limit]
+                processed_paths.add(data_path)
+
         # handling RETURN ID(A)
         for data_path in data_paths:
+            if data_path in processed_paths:
+                continue
             if isinstance(data_path, IDRef):
                 original_entity = data_path.entity_name
                 if original_entity in motif_nodes:
@@ -1074,7 +1175,7 @@ class GrandCypherExecutor:
 
         # Only after all other transformations, apply pagination
         results = self._apply_pagination(results, ignore_limit)
-        self._return_requests = [
+        return_requests = [
             r if isinstance(r, (EntityRef, AttributeRef, IDRef)) else str(r)
             for r in self._return_requests
         ]
@@ -1083,8 +1184,8 @@ class GrandCypherExecutor:
         results = {
             self._entity2alias.get(key, key): values
             for key, values in results.items()
-            if key in self._return_requests
-            or self._alias2entity.get(key, key) in self._return_requests
+            if key in return_requests
+            or self._alias2entity.get(key, key) in return_requests
         }
 
         # HACK: convert to [None] if edge is None
@@ -1513,6 +1614,15 @@ class GrandCypherTransformer(Transformer):
                     self._executors[-1]._aggregation_attributes.add(entity)
                     self._executors[-1]._aggregate_functions.append((func, entity))
                 else:
+                    if isinstance(item, Expression) and not isinstance(
+                        item, (EntityRef, AttributeRef, IDRef)
+                    ):
+                        request = str(item)
+                        self._executors[-1]._original_return_requests.add(request)
+                        if alias:
+                            self._executors[-1]._entity2alias[request] = alias
+                        self._executors[-1]._return_requests.append(item)
+                        continue
                     if not isinstance(item, str):
                         item = str(item.value)
                     self._executors[-1]._original_return_requests.add(item)
@@ -1763,6 +1873,27 @@ class GrandCypherTransformer(Transformer):
         # self._return_requests.append(entity_name)
         # Return a special identifier that will be processed in _lookup method
         return IDRef(entity_name)
+
+    def tolower_function(self, items):
+        return ScalarFunctionExpression("toLower", items[0], _lower)
+
+    def toupper_function(self, items):
+        return ScalarFunctionExpression("toUpper", items[0], _upper)
+
+    def trim_function(self, items):
+        return ScalarFunctionExpression("trim", items[0], _strip)
+
+    def coalesce_function(self, items):
+        return CoalesceExpression(items)
+
+    def size_function(self, items):
+        expression = ScalarFunctionExpression("size", items[0], len)
+        if isinstance(items[0], str) and not isinstance(items[0], Expression):
+            expression.argument_display = _format_expression(items[0])
+        return expression
+
+    def type_function(self, items):
+        return TypeExpression(items[0])
 
     def value_list(self, items):
         return list(items)

--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -26,7 +26,7 @@ from .indexer import (
     Compare as IndexerCompare, OR as IndexerOr,
     AND as IndexerAnd, ArrayAttributeIndexer, IndexerConditionAST,
     UnsupportedOp as IndexerUnsupportedOp, IndexerConditionRunner)
-from .types import Expression, EntityRef, AttributeRef, IDRef
+from .types import ExpressionBase, EntityRef, AttributeRef, IDRef
 
 
 _GrandCypherGrammar = Lark(
@@ -270,7 +270,7 @@ def _strip(value):
     return value.strip()
 
 
-class ArithmeticExpression:
+class ArithmeticExpression(ExpressionBase):
     def __init__(self, left, op: str, right):
         self.left = left
         self.op = op
@@ -288,7 +288,7 @@ class ArithmeticExpression:
         return f"({self.left} {self.op} {self.right})"
 
 
-class ScalarFunctionExpression:
+class ScalarFunctionExpression(ExpressionBase):
     def __init__(self, name, argument, function):
         self.name = name
         self.argument = argument
@@ -303,7 +303,7 @@ class ScalarFunctionExpression:
         return f"{self.name}({argument})"
 
 
-class CoalesceExpression:
+class CoalesceExpression(ExpressionBase):
     def __init__(self, arguments):
         self.arguments = arguments
 
@@ -318,7 +318,7 @@ class CoalesceExpression:
         return f"coalesce({', '.join(_format_expression(arg) for arg in self.arguments)})"
 
 
-class TypeExpression:
+class TypeExpression(ExpressionBase):
     def __init__(self, argument):
         self.argument = argument
 
@@ -339,19 +339,19 @@ class TypeExpression:
 
 
 def _evaluate_expression(value, match, host, return_edges, scope=None):
-    if isinstance(value, Expression):
+    if isinstance(value, ExpressionBase):
         return value.evaluate(match, host, return_edges, scope)
     return value
 
 
 def _format_expression(value):
-    if isinstance(value, str) and not isinstance(value, Expression):
+    if isinstance(value, str) and not isinstance(value, ExpressionBase):
         return f'"{value}"'
     return str(value)
 
 
 def _resolve_operand(operand, match, host, return_edges):
-    if isinstance(operand, Expression):
+    if isinstance(operand, ExpressionBase):
         return operand.evaluate(match, host, return_edges)
     return operand
 
@@ -984,7 +984,7 @@ class GrandCypherExecutor:
         processed_paths = set()  # Keep track of processed paths
 
         for data_path in data_paths:
-            if isinstance(data_path, Expression) and not isinstance(
+            if isinstance(data_path, ExpressionBase) and not isinstance(
                 data_path, (EntityRef, AttributeRef, IDRef)
             ):
                 result[str(data_path)] = [
@@ -1614,7 +1614,7 @@ class GrandCypherTransformer(Transformer):
                     self._executors[-1]._aggregation_attributes.add(entity)
                     self._executors[-1]._aggregate_functions.append((func, entity))
                 else:
-                    if isinstance(item, Expression) and not isinstance(
+                    if isinstance(item, ExpressionBase) and not isinstance(
                         item, (EntityRef, AttributeRef, IDRef)
                     ):
                         request = str(item)
@@ -1888,7 +1888,7 @@ class GrandCypherTransformer(Transformer):
 
     def size_function(self, items):
         expression = ScalarFunctionExpression("size", items[0], len)
-        if isinstance(items[0], str) and not isinstance(items[0], Expression):
+        if isinstance(items[0], str) and not isinstance(items[0], ExpressionBase):
             expression.argument_display = _format_expression(items[0])
         return expression
 

--- a/grandcypher/test_scalar_functions.py
+++ b/grandcypher/test_scalar_functions.py
@@ -1,0 +1,102 @@
+import pickle
+
+import networkx as nx
+
+from . import GrandCypher, _GrandCypherGrammar
+
+
+def test_string_functions_in_return_and_where():
+    host = nx.DiGraph()
+    host.add_node("a", name="  ALICE  ")
+    host.add_node("b", name=" Bob ")
+
+    result = GrandCypher(host).run(
+        'MATCH (n) WHERE toLower(trim(n.name)) = "alice" '
+        "RETURN n.name, toLower(n.name), toUpper(trim(n.name))"
+    )
+
+    assert result == {
+        "n.name": ["  ALICE  "],
+        "toLower(n.name)": ["  alice  "],
+        "toUpper(trim(n.name))": ["ALICE"],
+    }
+
+
+def test_coalesce_with_attributes_and_literals():
+    host = nx.DiGraph()
+    host.add_node("a", name="Alice")
+    host.add_node("b", nickname="Bobby")
+    host.add_node("c")
+
+    result = GrandCypher(host).run(
+        'MATCH (n) RETURN coalesce(n.name, n.nickname, "Unknown") AS display'
+    )
+
+    assert result["display"] == ["Alice", "Bobby", "Unknown"]
+
+
+def test_coalesce_reads_edge_attributes():
+    host = nx.DiGraph()
+    host.add_edge("a", "b", fallback="edge value")
+
+    result = GrandCypher(host).run(
+        "MATCH (a)-[r]->(b) RETURN coalesce(r.missing, r.fallback)"
+    )
+
+    assert result["coalesce(r.missing, r.fallback)"] == ["edge value"]
+
+
+def test_size_with_string_attribute_and_literal():
+    host = nx.DiGraph()
+    host.add_node("a", name="Alice")
+    host.add_node("b", name=None)
+
+    result = GrandCypher(host).run(
+        'MATCH (n) WHERE size("hello") = 5 RETURN size(n.name), size("hello")'
+    )
+
+    assert result["size(n.name)"] == [5, None]
+    assert result['size("hello")'] == [5, 5]
+
+
+def test_type_with_multigraph_relationships():
+    host = nx.MultiDiGraph()
+    host.add_edge("a", "b", __labels__={"PAID"})
+    host.add_edge("a", "b", __labels__={"OWES"})
+
+    result = GrandCypher(host).run(
+        'MATCH (a)-[r]->(b) WHERE type(r) = "PAID" RETURN type(r) AS kind'
+    )
+
+    assert result["kind"] == ["PAID"]
+
+
+def test_scalar_function_arithmetic_composition():
+    host = nx.DiGraph()
+    host.add_node("a", name="Alice")
+    host.add_node("b", name="Bob")
+
+    result = GrandCypher(host).run(
+        "MATCH (n) WHERE size(n.name) + 1 > 4 RETURN n.name"
+    )
+
+    assert result["n.name"] == ["Alice"]
+
+
+def test_scalar_query_can_be_reused():
+    host = nx.DiGraph()
+    host.add_node("a", name="Alice")
+    grand_cypher = GrandCypher(host)
+    query = "MATCH (n) RETURN toLower(n.name)"
+
+    assert grand_cypher.run(query) == {"toLower(n.name)": ["alice"]}
+    assert grand_cypher.run(query) == {"toLower(n.name)": ["alice"]}
+
+
+def test_scalar_expression_is_picklable():
+    tree = _GrandCypherGrammar.parse("MATCH (n) RETURN toLower(n.name)")
+    grand_cypher = GrandCypher(nx.DiGraph())
+    grand_cypher._transformer.transform(tree)
+    expression = grand_cypher._transformer._executors[0]._return_requests[0]
+
+    assert str(pickle.loads(pickle.dumps(expression))) == "toLower(n.name)"

--- a/grandcypher/types.py
+++ b/grandcypher/types.py
@@ -11,7 +11,11 @@ class Expression(Protocol):
         ...
 
 
-class EntityRef(str):
+class ExpressionBase:
+    """Marker base for efficient runtime expression dispatch."""
+
+
+class EntityRef(str, ExpressionBase):
     """Bare node/edge reference, e.g. A.
 
     str subclass because the RETURN path uses these as dict keys
@@ -32,7 +36,7 @@ class EntityRef(str):
         )
 
 
-class AttributeRef(str):
+class AttributeRef(str, ExpressionBase):
     """Node/edge attribute reference, e.g. A.age.
 
     str subclass because the RETURN path uses these as dict keys
@@ -62,7 +66,7 @@ class AttributeRef(str):
         raise IndexError(f"Entity {self} not in graph.")
 
 
-class IDRef(str):
+class IDRef(str, ExpressionBase):
     """Reference to ID(A) in WHERE clauses.
 
     str subclass because the RETURN path uses these as dict keys


### PR DESCRIPTION
Adds `toLower`, `toUpper`, `trim`, `coalesce`, `size`, and relationship type expressions for use in WHERE and RETURN clauses. Supports aliases, nesting, arithmetic composition, edge attributes, query reuse, and pickling while preserving the existing aggregation implementation.