### PR TITLE
Add scoped expression evaluation

### DIFF
--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -277,8 +277,8 @@ class ArithmeticExpression(ExpressionBase):
         self.right = right
 
     def evaluate(self, match, host, return_edges, scope=None):
-        left_val = _resolve_operand(self.left, match, host, return_edges)
-        right_val = _resolve_operand(self.right, match, host, return_edges)
+        left_val = _resolve_operand(self.left, match, host, return_edges, scope)
+        right_val = _resolve_operand(self.right, match, host, return_edges, scope)
         try:
             return _ARITH_OPS[self.op](left_val, right_val)
         except (TypeError, ZeroDivisionError, OverflowError):
@@ -421,9 +421,9 @@ def _format_expression(value):
     return str(value)
 
 
-def _resolve_operand(operand, match, host, return_edges):
+def _resolve_operand(operand, match, host, return_edges, scope=None):
     if isinstance(operand, ExpressionBase):
-        return operand.evaluate(match, host, return_edges)
+        return operand.evaluate(match, host, return_edges, scope)
     return operand
 
 
@@ -839,12 +839,12 @@ class CompoundCondition(Condition):
     def __str__(self):
         return f"compound of {self._operator} for {self._left}: {self._right}"
 
-    def __call__(self, match: Match, host: nx.DiGraph, return_edges: list) -> bool:
+    def __call__(self, match: Match, host: nx.DiGraph, return_edges: list, scope=None) -> bool:
         if isinstance(self._operator, SUBOP):
             val = self._operator(match.node_mappings, self._right)
         else:
-            left = _resolve_operand(self._left, match, host, return_edges)
-            right = _resolve_operand(self._right, match, host, return_edges)
+            left = _resolve_operand(self._left, match, host, return_edges, scope)
+            right = _resolve_operand(self._right, match, host, return_edges, scope)
             try:
                 val = self._operator(left, right)
             except (TypeError, AttributeError):

--- a/grandcypher/test_scoped_expressions.py
+++ b/grandcypher/test_scoped_expressions.py
@@ -1,0 +1,84 @@
+import networkx as nx
+
+from . import (
+    ArithmeticExpression,
+    CompoundCondition,
+    ScalarFunctionExpression,
+    _OPERATORS,
+    _lower,
+)
+from .struct import Match
+from .types import AttributeRef, EntityRef
+
+
+def _match(**node_mappings):
+    return Match(
+        node_mappings=node_mappings,
+        where_results=None,
+        edge_mapping=None,
+    )
+
+
+def test_entity_ref_resolves_scoped_value():
+    assert EntityRef("item").evaluate(
+        _match(), nx.DiGraph(), {}, scope={"item": {"value": 3}}
+    ) == {"value": 3}
+
+
+def test_attribute_ref_resolves_scoped_attribute():
+    assert AttributeRef("item", "value").evaluate(
+        _match(), nx.DiGraph(), {}, scope={"item": {"value": 3}}
+    ) == 3
+
+
+def test_scope_shadows_graph_entity():
+    host = nx.DiGraph()
+    host.add_node("graph-node", value=1)
+    match = _match(item="graph-node")
+
+    assert AttributeRef("item", "value").evaluate(
+        match, host, {}, scope={"item": {"value": 2}}
+    ) == 2
+
+
+def test_missing_scoped_attribute_returns_none():
+    assert AttributeRef("item", "missing").evaluate(
+        _match(), nx.DiGraph(), {}, scope={"item": {"value": 3}}
+    ) is None
+
+
+def test_non_mapping_scoped_attribute_returns_none():
+    assert AttributeRef("item", "value").evaluate(
+        _match(), nx.DiGraph(), {}, scope={"item": 3}
+    ) is None
+
+
+def test_attribute_ref_falls_back_to_graph_without_scope_entry():
+    host = nx.DiGraph()
+    host.add_node("graph-node", value=1)
+
+    assert AttributeRef("item", "value").evaluate(
+        _match(item="graph-node"), host, {}, scope={"other": 2}
+    ) == 1
+
+
+def test_scope_propagates_through_scalar_and_arithmetic_expressions():
+    lower = ScalarFunctionExpression("toLower", AttributeRef("item", "name"), _lower)
+    expression = ArithmeticExpression(AttributeRef("item", "value"), "+", 2)
+    scope = {"item": {"name": "ALICE", "value": 3}}
+
+    assert lower.evaluate(_match(), nx.DiGraph(), {}, scope) == "alice"
+    assert expression.evaluate(_match(), nx.DiGraph(), {}, scope) == 5
+
+
+def test_scope_propagates_through_compound_condition():
+    condition = CompoundCondition(
+        True,
+        AttributeRef("item", "value"),
+        _OPERATORS[">"],
+        2,
+    )
+
+    assert condition(
+        _match(), nx.DiGraph(), {}, scope={"item": {"value": 3}}
+    ) == (True, [True])

--- a/grandcypher/types.py
+++ b/grandcypher/types.py
@@ -30,6 +30,8 @@ class EntityRef(str, ExpressionBase):
         return (self.entity_name,)
 
     def evaluate(self, match, host, return_edges, scope=None):
+        if scope is not None and self.entity_name in scope:
+            return scope[self.entity_name]
         raise TypeError(
             f"Cannot use bare entity '{self}' in a comparison. "
             f"Use a property like '{self}.attribute' or ID({self})."
@@ -52,6 +54,9 @@ class AttributeRef(str, ExpressionBase):
         return (self.entity_name, self.attribute)
 
     def evaluate(self, match, host, return_edges, scope=None):
+        if scope is not None and self.entity_name in scope:
+            value = scope[self.entity_name]
+            return value.get(self.attribute) if isinstance(value, dict) else None
         if self.entity_name in match.node_mappings:
             host_node_id = match.node_mappings[self.entity_name]
             return host.nodes[host_node_id].get(self.attribute)


### PR DESCRIPTION
Adds temporary scope resolution to typed references and propagates scope through scalar functions, arithmetic expressions, and compound comparisons while preserving normal graph resolution behavior.