### PR TITLE
Add relationship list predicates

### DIFF
--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -52,6 +52,7 @@ compound_condition  : condition
 
 condition           : arith_expr op arith_expr
                     | (entity_id | scalar_function) op_list value_list  // IN: no arithmetic on LHS by design
+                    | list_predicate
                     | sub_query
                     | "not"i condition -> condition_not
 
@@ -66,6 +67,7 @@ condition           : arith_expr op arith_expr
 
 ?arith_atom         : entity_id
                     | scalar_function
+                    | relationship_list
                     | value
                     | NULL -> null
                     | TRUE -> true
@@ -111,7 +113,13 @@ attribute_id         : CNAME
                     | "size"i "(" expression_argument ")" -> size_function
                     | "type"i "(" entity_id ")" -> type_function
 
+relationship_list    : "relationships"i "(" entity_id ")" -> relationships_function
+
+list_predicate       : LIST_PREDICATE "(" CNAME "in"i relationship_list "where"i compound_condition ")" -> list_predicate
+LIST_PREDICATE       : "all"i | "any"i | "none"i | "single"i
+
 ?expression_argument : scalar_function
+                     | relationship_list
                      | entity_id
                      | value
                      | NULL -> null
@@ -248,6 +256,10 @@ _SUB_OPERATORS = {
 }
 
 
+class Condition:
+    pass
+
+
 _ARITH_OPS = {
     "+": lambda a, b: a + b,
     "-": lambda a, b: a - b,
@@ -336,6 +348,64 @@ class TypeExpression(ExpressionBase):
 
     def __str__(self):
         return f"type({self.argument})"
+
+
+class RelationshipsExpression(ExpressionBase):
+    def __init__(self, argument):
+        self.argument = argument
+
+    def evaluate(self, match, host, return_edges, scope=None):
+        if self.argument not in return_edges:
+            return None
+        motif_edge = return_edges[self.argument]
+        return [
+            dict(host.edges[edge.u, edge.v, edge.k])
+            if host.is_multigraph()
+            else dict(host.edges[edge.u, edge.v])
+            for edge in match.mth.edge(*motif_edge).edges
+        ]
+
+    def __str__(self):
+        return f"relationships({self.argument})"
+
+
+class ListPredicateExpression(Condition):
+    def __init__(self, name, variable, expression, condition):
+        self.name = name.upper()
+        self.variable = variable
+        self.expression = expression
+        self.condition = condition
+
+    def __call__(self, match, host, return_edges, scope=None):
+        values = self.expression.evaluate(match, host, return_edges, scope)
+        if values is None:
+            return None, [None]
+
+        results = []
+        for value in values:
+            item_scope = dict(scope or {})
+            item_scope[self.variable] = value
+            _, operator_results = self.condition(match, host, return_edges, item_scope)
+            results.append(operator_results[-1])
+
+        if self.name == "ALL":
+            value = False if False in results else None if None in results else True
+        elif self.name == "ANY":
+            value = True if True in results else None if None in results else False
+        elif self.name == "NONE":
+            value = False if True in results else None if None in results else True
+        elif self.name == "SINGLE":
+            true_count = results.count(True)
+            value = (
+                False
+                if true_count > 1
+                else None
+                if None in results
+                else true_count == 1
+            )
+        else:
+            raise ValueError(f"Unsupported list predicate: {self.name}")
+        return value, [value]
 
 
 class AggregationExpression:
@@ -778,10 +848,6 @@ def generate_multiedge_edge_hop_key(
 
 CONDITION = Callable[[dict, nx.DiGraph, list], bool]
 
-
-class Condition:
-    ...
-
 class BoolCondition(Condition):
     ...
 
@@ -792,9 +858,9 @@ class AND(BoolCondition):
         self._condition_b = condition_b
         self._operator = "and"
 
-    def __call__(self, match: dict, host: nx.DiGraph, return_edges: list) -> bool:
-        condition_a, where_a = self._condition_a(match, host, return_edges)
-        condition_b, where_b = self._condition_b(match, host, return_edges)
+    def __call__(self, match: dict, host: nx.DiGraph, return_edges: list, scope=None) -> bool:
+        condition_a, where_a = self._condition_a(match, host, return_edges, scope)
+        condition_b, where_b = self._condition_b(match, host, return_edges, scope)
         where_result = [a and b for a, b in zip(where_a, where_b)]
         return (condition_a and condition_b), where_result
 
@@ -805,9 +871,9 @@ class OR(BoolCondition):
         self._condition_b = condition_b
         self._operator = "or"
 
-    def __call__(self, match: dict, host: nx.DiGraph, return_edges: list) -> tuple[bool, dict]:
-        condition_a, where_a = self._condition_a(match, host, return_edges)
-        condition_b, where_b = self._condition_b(match, host, return_edges)
+    def __call__(self, match: dict, host: nx.DiGraph, return_edges: list, scope=None) -> tuple[bool, dict]:
+        condition_a, where_a = self._condition_a(match, host, return_edges, scope)
+        condition_b, where_b = self._condition_b(match, host, return_edges, scope)
         where_result = [a or b for a, b in zip(where_a, where_b)]
         return (condition_a or condition_b), where_result
 
@@ -1863,6 +1929,8 @@ class GrandCypherTransformer(Transformer):
 
     def compound_condition(self, val):
         if len(val) == 1:
+            if isinstance(val[0], ListPredicateExpression):
+                return val[0]
             val = CompoundCondition(*val[0])
         else:  # len == 3
             compound_a, operator, compound_b = val
@@ -1878,6 +1946,9 @@ class GrandCypherTransformer(Transformer):
     def condition(self, condition):
         if len(condition) == 1:  # sub query
             condition = condition[0]
+
+        if isinstance(condition, Condition):
+            return condition
 
         if len(condition) == 3:
             (entity_id, operator, value) = condition
@@ -1920,6 +1991,14 @@ class GrandCypherTransformer(Transformer):
 
     def type_function(self, items):
         return TypeExpression(items[0])
+
+    def relationships_function(self, items):
+        return RelationshipsExpression(items[0])
+
+    def list_predicate(self, items):
+        return ListPredicateExpression(
+            str(items[0]), str(items[1]), items[2], items[3]
+        )
 
     def value_list(self, items):
         return list(items)

--- a/grandcypher/test_relationship_list_predicates.py
+++ b/grandcypher/test_relationship_list_predicates.py
@@ -1,0 +1,165 @@
+import networkx as nx
+import pytest
+
+from . import (
+    CompoundCondition,
+    GrandCypher,
+    ListPredicateExpression,
+    _OPERATORS,
+)
+from .struct import Match
+from .types import AttributeRef
+
+
+class EmptyListExpression:
+    def evaluate(self, match, host, return_edges, scope=None):
+        return []
+
+
+@pytest.fixture
+def path_graph():
+    host = nx.DiGraph()
+    host.add_node("a", name="Alice")
+    host.add_node("b", name="Bob")
+    host.add_node("c", name="Charlie")
+    host.add_node("d", name="David")
+    host.add_edge("a", "b", weight=10, kind="friend")
+    host.add_edge("b", "c", weight=20, kind="friend")
+    host.add_edge("c", "d", weight=5, kind="blocked")
+    return host
+
+
+def test_relationships_supports_size_in_where_and_return(path_graph):
+    result = GrandCypher(path_graph).run(
+        "MATCH (a)-[r*1..3]->(b) "
+        "WHERE size(relationships(r)) = 2 "
+        "RETURN a.name, b.name, size(relationships(r)) AS length"
+    )
+
+    assert result == {
+        "a.name": ["Alice", "Bob"],
+        "b.name": ["Charlie", "David"],
+        "length": [2, 2],
+    }
+
+
+@pytest.mark.parametrize(
+    ("predicate", "comparison", "starts"),
+    [
+        ("ALL", "edge.weight > 5", {"Alice"}),
+        ("ANY", "edge.weight > 15", {"Alice", "Bob"}),
+        ("NONE", "edge.weight < 10", {"Alice"}),
+        ("SINGLE", "edge.weight > 15", {"Alice", "Bob"}),
+    ],
+)
+def test_list_predicates(path_graph, predicate, comparison, starts):
+    result = GrandCypher(path_graph).run(
+        f"MATCH (a)-[r*2]->(b) "
+        f"WHERE {predicate}(edge IN relationships(r) WHERE {comparison}) "
+        "RETURN a.name"
+    )
+
+    assert set(result["a.name"]) == starts
+
+
+def test_compound_inner_predicate_and_outer_boolean(path_graph):
+    result = GrandCypher(path_graph).run(
+        "MATCH (a)-[r*2]->(b) "
+        "WHERE ALL(edge IN relationships(r) "
+        'WHERE edge.weight > 5 AND edge.kind = "friend") '
+        'AND a.name = "Alice" '
+        "RETURN b.name"
+    )
+
+    assert result == {"b.name": ["Charlie"]}
+
+
+def test_list_predicate_outer_or(path_graph):
+    result = GrandCypher(path_graph).run(
+        "MATCH (a)-[r*2]->(b) "
+        "WHERE ALL(edge IN relationships(r) WHERE edge.weight > 100) "
+        'OR a.name = "Alice" '
+        "RETURN a.name"
+    )
+
+    assert result == {"a.name": ["Alice"]}
+
+
+@pytest.mark.parametrize(
+    ("predicate", "expected"),
+    [
+        ("ALL", []),
+        ("ANY", ["a"]),
+        ("NONE", []),
+        ("SINGLE", []),
+    ],
+)
+def test_list_predicate_mixed_true_and_null_semantics(predicate, expected):
+    host = nx.DiGraph()
+    host.add_edge("a", "b", weight=10)
+    host.add_edge("b", "c")
+
+    result = GrandCypher(host).run(
+        f"MATCH (a)-[r*2]->(b) "
+        f"WHERE {predicate}(edge IN relationships(r) WHERE edge.weight > 5) "
+        "RETURN ID(a)"
+    )
+
+    assert result == {"ID(a)": expected}
+
+
+@pytest.mark.parametrize("predicate", ["ALL", "ANY", "NONE", "SINGLE"])
+def test_list_predicate_null_only_is_filtered(predicate):
+    host = nx.DiGraph()
+    host.add_edge("a", "b")
+
+    result = GrandCypher(host).run(
+        f"MATCH (a)-[r]->(b) "
+        f"WHERE {predicate}(edge IN relationships(r) WHERE edge.weight > 5) "
+        "RETURN ID(a)"
+    )
+
+    assert result == {"ID(a)": []}
+
+
+def test_relationships_uses_selected_multigraph_edges():
+    host = nx.MultiDiGraph()
+    host.add_edge("a", "b", weight=1)
+    host.add_edge("a", "b", weight=10)
+
+    result = GrandCypher(host).run(
+        "MATCH (a)-[r]->(b) "
+        "WHERE ALL(edge IN relationships(r) WHERE edge.weight > 5) "
+        "RETURN r.weight"
+    )
+
+    assert result == {"r.weight": [10]}
+
+
+def test_relationship_predicate_query_can_be_reused(path_graph):
+    grand_cypher = GrandCypher(path_graph)
+    query = (
+        "MATCH (a)-[r*2]->(b) "
+        "WHERE ANY(edge IN relationships(r) WHERE edge.weight > 15) "
+        "RETURN a.name"
+    )
+
+    expected = {"a.name": ["Alice", "Bob"]}
+    assert grand_cypher.run(query) == expected
+    assert grand_cypher.run(query) == expected
+
+
+@pytest.mark.parametrize(
+    ("predicate", "expected"),
+    [("ALL", True), ("ANY", False), ("NONE", True), ("SINGLE", False)],
+)
+def test_empty_list_semantics(predicate, expected):
+    condition = CompoundCondition(
+        True, AttributeRef("edge", "weight"), _OPERATORS[">"], 5
+    )
+    list_predicate = ListPredicateExpression(
+        predicate, "edge", EmptyListExpression(), condition
+    )
+    match = Match(node_mappings={}, where_results=None, edge_mapping=None)
+
+    assert list_predicate(match, nx.DiGraph(), {}) == (expected, [expected])


### PR DESCRIPTION
Adds relationships() for materializing selected path relationships and implements ALL, ANY, NONE, and SINGLE predicates with scoped loop variables, compound conditions, multigraph support, and Cypher-compatible null semantics.