### PR TITLE
Support nested query expressions

### DIFF
--- a/grandcypher/__init__.py
+++ b/grandcypher/__init__.py
@@ -101,7 +101,7 @@ return_clause       : "return"i distinct_return? return_item ("," return_item)*
 return_item         : (entity_id | aggregation_function | scalar_function) ( "AS"i alias )?
 alias               : CNAME
 
-aggregation_function : AGGREGATE_FUNC "(" entity_id ( "." attribute_id )? ")"
+aggregation_function : AGGREGATE_FUNC "(" expression_argument ")"
 AGGREGATE_FUNC       : "COUNT" | "SUM" | "AVG" | "MAX" | "MIN" | "COLLECT"
 attribute_id         : CNAME
 
@@ -414,9 +414,23 @@ class AggregationExpression:
     def __init__(self, argument):
         self.argument = argument
 
-    def evaluate(self, results, group_keys):
+    @property
+    def is_computed(self):
+        return not isinstance(self.argument, (EntityRef, AttributeRef, IDRef))
+
+    def evaluate(self, results, group_keys, matches=None, host=None, return_edges=None):
+        if isinstance(self.argument, str) and self.argument in results:
+            values = results[self.argument]
+        elif self.is_computed:
+            values = [
+                _evaluate_expression(self.argument, match, host, return_edges)
+                for match in matches or []
+            ]
+        else:
+            values = results[self.argument]
+
         grouped_data = {}
-        for i, value in enumerate(results[self.argument]):
+        for i, value in enumerate(values):
             group = tuple(results[key][i] for key in group_keys if key in results)
             grouped_data.setdefault(group, []).append(value)
 
@@ -1233,13 +1247,23 @@ class GrandCypherExecutor:
             group_keys = [
                 key
                 for key in results.keys()
-                if not any(key.endswith(func.argument) for func in self._aggregate_functions)
+                if not any(
+                    not func.is_computed
+                    and key.endswith(func.argument)
+                    for func in self._aggregate_functions
+                )
             ]
 
             aggregated_results = {}
             aggregation_keys = None
             for func in self._aggregate_functions:
-                aggregated_data = func.evaluate(results, group_keys)
+                aggregated_data = func.evaluate(
+                    results,
+                    group_keys,
+                    matches=self._get_true_matches(),
+                    host=self._target_graph,
+                    return_edges=self._return_edges,
+                )
                 aggregated_values = list(aggregated_data.values())
                 current_keys = list(aggregated_data.keys())
                 if aggregation_keys is None:
@@ -1703,7 +1727,8 @@ class GrandCypherTransformer(Transformer):
                     func = self._parse_aggregation_token(item)
                     if alias:
                         self._executors[-1]._entity2alias[str(func)] = alias
-                    self._executors[-1]._aggregation_attributes.add(func.argument)
+                    if not func.is_computed:
+                        self._executors[-1]._aggregation_attributes.add(func.argument)
                     self._executors[-1]._aggregate_functions.append(func)
                 else:
                     if isinstance(item, ExpressionBase) and not isinstance(
@@ -1726,17 +1751,9 @@ class GrandCypherTransformer(Transformer):
         self._executors[-1]._alias2entity.update({v: k for k, v in self._executors[-1]._entity2alias.items()})
 
     def _parse_aggregation_token(self, item: Tree):
-        """
-        Parse the aggregation function token and return the function and entity
-            input: Tree('aggregation_function', [Token('AGGREGATE_FUNC', 'SUM'), Token('CNAME', 'r'), Tree('attribute_id', [Token('CNAME', 'value')])])
-            output: ('SUM', 'r.value')
-        """
-        func = str(item.children[0].value)  # AGGREGATE_FUNC
-        entity = str(item.children[1].value)
-        if len(item.children) > 2:
-            entity += "." + str(item.children[2].children[0].value)
-
-        return _AGGREGATION_FUNCTIONS[func](entity)
+        """Build an aggregation expression from its parsed argument expression."""
+        func = str(item.children[0].value)
+        return _AGGREGATION_FUNCTIONS[func](item.children[1])
 
     def _extract_alias(self, item: Tree):
         """
@@ -1771,7 +1788,8 @@ class GrandCypherTransformer(Transformer):
             ):
                 func = self._parse_aggregation_token(item.children[0])
                 field = str(func)
-                self._executors[-1]._order_by_attributes.add(func.argument)
+                if not func.is_computed:
+                    self._executors[-1]._order_by_attributes.add(func.argument)
             else:
                 field = str(
                     item.children[0]

--- a/grandcypher/test_collect.py
+++ b/grandcypher/test_collect.py
@@ -1,4 +1,5 @@
 import networkx as nx
+import pytest
 
 from . import Collect, GrandCypher
 
@@ -83,3 +84,17 @@ def test_collect_query_can_be_reused():
     expected = {"COLLECT(n.value)": [[1, 2]]}
     assert grand_cypher.run(query) == expected
     assert grand_cypher.run(query) == expected
+
+
+@pytest.mark.benchmark
+def test_benchmark_grouped_collect():
+    host = nx.DiGraph()
+    host.add_nodes_from(
+        (index, {"group": index % 20, "value": index}) for index in range(500)
+    )
+
+    result = GrandCypher(host).run(
+        "MATCH (n) RETURN n.group, COLLECT(n.value)"
+    )
+
+    assert len(result["n.group"]) == 20

--- a/grandcypher/test_nested_expressions.py
+++ b/grandcypher/test_nested_expressions.py
@@ -1,4 +1,5 @@
 import networkx as nx
+import pytest
 
 from . import GrandCypher
 
@@ -110,3 +111,18 @@ def test_nested_expression_query_can_be_reused():
     expected = {"AVG(size(n.name))": [3]}
     assert grand_cypher.run(query) == expected
     assert grand_cypher.run(query) == expected
+
+
+@pytest.mark.benchmark
+def test_benchmark_nested_scalar_aggregation():
+    host = nx.DiGraph()
+    host.add_nodes_from(
+        (index, {"group": index % 20, "name": f"name-{index}"})
+        for index in range(500)
+    )
+
+    result = GrandCypher(host).run(
+        "MATCH (n) RETURN n.group, AVG(size(n.name))"
+    )
+
+    assert len(result["n.group"]) == 20

--- a/grandcypher/test_nested_expressions.py
+++ b/grandcypher/test_nested_expressions.py
@@ -1,0 +1,112 @@
+import networkx as nx
+
+from . import GrandCypher
+
+
+def test_scalar_to_scalar_comparison():
+    host = nx.DiGraph()
+    host.add_node("a", first=" ALICE ", second="alice")
+    host.add_node("b", first="BOB", second="alice")
+
+    result = GrandCypher(host).run(
+        "MATCH (n) WHERE toLower(trim(n.first)) = toLower(n.second) "
+        "RETURN ID(n)"
+    )
+
+    assert result == {"ID(n)": ["a"]}
+
+
+def test_aggregation_over_scalar_expression_with_alias_and_order():
+    host = nx.DiGraph()
+    host.add_nodes_from(
+        [
+            ("a", {"group": "x", "name": "Al"}),
+            ("b", {"group": "x", "name": "Beth"}),
+            ("c", {"group": "y", "name": "Charlie"}),
+        ]
+    )
+
+    result = GrandCypher(host).run(
+        "MATCH (n) RETURN n.group, AVG(size(n.name)) AS average "
+        "ORDER BY AVG(size(n.name)) DESC"
+    )
+
+    assert result == {"n.group": ["y", "x"], "average": [7, 3]}
+
+
+def test_all_aggregations_accept_scalar_expressions():
+    host = nx.DiGraph()
+    host.add_nodes_from([("a", {"name": "Al"}), ("b", {"name": "Beth"})])
+
+    result = GrandCypher(host).run(
+        "MATCH (n) RETURN COUNT(size(n.name)), SUM(size(n.name)), "
+        "MIN(size(n.name)), MAX(size(n.name)), COLLECT(size(n.name))"
+    )
+
+    assert result == {
+        "COUNT(size(n.name))": [2],
+        "SUM(size(n.name))": [6],
+        "MIN(size(n.name))": [2],
+        "MAX(size(n.name))": [4],
+        "COLLECT(size(n.name))": [[2, 4]],
+    }
+
+
+def test_nested_aggregation_preserves_null_behavior():
+    host = nx.DiGraph()
+    host.add_nodes_from([("a", {"name": "Al"}), ("b", {})])
+
+    result = GrandCypher(host).run(
+        "MATCH (n) RETURN COLLECT(size(n.name)), SUM(size(n.name))"
+    )
+
+    assert result == {
+        "COLLECT(size(n.name))": [[2]],
+        "SUM(size(n.name))": [2],
+    }
+
+
+def test_aggregation_accepts_literal_arguments():
+    host = nx.DiGraph()
+    host.add_nodes_from(["a", "b"])
+
+    result = GrandCypher(host).run(
+        "MATCH (n) RETURN COUNT(1), SUM(2), COLLECT(3)"
+    )
+
+    assert result == {"COUNT(1)": [2], "SUM(2)": [4], "COLLECT(3)": [[3, 3]]}
+
+
+def test_aggregation_over_relationship_list_size():
+    host = nx.DiGraph()
+    host.add_edge("a", "b")
+    host.add_edge("b", "c")
+
+    result = GrandCypher(host).run(
+        "MATCH (a)-[r*1..2]->(b) RETURN AVG(size(relationships(r)))"
+    )
+
+    assert result == {"AVG(size(relationships(r)))": [4 / 3]}
+
+
+def test_aggregation_over_multigraph_relationship_type():
+    host = nx.MultiDiGraph()
+    host.add_edge("a", "b", __labels__={"PAID"})
+    host.add_edge("a", "b", __labels__={"OWES"})
+
+    result = GrandCypher(host).run(
+        "MATCH (a)-[r]->(b) RETURN COLLECT(type(r))"
+    )
+
+    assert result == {"COLLECT(type(r))": [["PAID", "OWES"]]}
+
+
+def test_nested_expression_query_can_be_reused():
+    host = nx.DiGraph()
+    host.add_nodes_from([("a", {"name": "Al"}), ("b", {"name": "Beth"})])
+    grand_cypher = GrandCypher(host)
+    query = "MATCH (n) RETURN AVG(size(n.name))"
+
+    expected = {"AVG(size(n.name))": [3]}
+    assert grand_cypher.run(query) == expected
+    assert grand_cypher.run(query) == expected

--- a/grandcypher/test_relationship_list_predicates.py
+++ b/grandcypher/test_relationship_list_predicates.py
@@ -149,6 +149,21 @@ def test_relationship_predicate_query_can_be_reused(path_graph):
     assert grand_cypher.run(query) == expected
 
 
+@pytest.mark.benchmark
+def test_benchmark_relationship_list_predicate():
+    host = nx.DiGraph()
+    for index in range(100):
+        host.add_edge(index, index + 1, weight=index % 10)
+
+    result = GrandCypher(host).run(
+        "MATCH (a)-[r*2]->(b) "
+        "WHERE ALL(edge IN relationships(r) WHERE edge.weight >= 0) "
+        "RETURN ID(a)"
+    )
+
+    assert len(result["ID(a)"]) == 99
+
+
 @pytest.mark.parametrize(
     ("predicate", "expected"),
     [("ALL", True), ("ANY", False), ("NONE", True), ("SINGLE", False)],

--- a/grandcypher/test_scalar_functions.py
+++ b/grandcypher/test_scalar_functions.py
@@ -1,6 +1,7 @@
 import pickle
 
 import networkx as nx
+import pytest
 
 from . import GrandCypher, _GrandCypherGrammar
 
@@ -20,6 +21,20 @@ def test_string_functions_in_return_and_where():
         "toLower(n.name)": ["  alice  "],
         "toUpper(trim(n.name))": ["ALICE"],
     }
+
+
+@pytest.mark.benchmark
+def test_benchmark_nested_scalar_filtering():
+    host = nx.DiGraph()
+    host.add_nodes_from(
+        (index, {"name": f"  USER-{index % 25}  "}) for index in range(250)
+    )
+
+    result = GrandCypher(host).run(
+        'MATCH (n) WHERE toLower(trim(n.name)) = "user-7" RETURN ID(n)'
+    )
+
+    assert len(result["ID(n)"]) == 10
 
 
 def test_coalesce_with_attributes_and_literals():


### PR DESCRIPTION
Allows scalar and relationship expressions to compose inside aggregations and comparisons, including aliases and aggregate ordering.

Example:
```cypher
MATCH (n)
RETURN n.group, AVG(size(n.name)) AS average
ORDER BY AVG(size(n.name)) DESC
```